### PR TITLE
PR Preview Workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,6 +60,10 @@ jobs:
           git commit -m "Deploy preview for PR #${PR_NUMBER}"
           git push
 
+      - name: Get PR number
+        id: get_pr_number
+        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
   delete-preview-directory:
     if: github.event.action == 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -81,3 +85,22 @@ jobs:
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  comment-preview-url:
+    needs: build-and-preview
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR number
+        run: echo "PR_NUMBER=${{ needs.build-and-preview.outputs.PR_NUMBER }}" >> $GITHUB_ENV
+
+      - name: Comment Preview URL
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+            const commentBody = `Preview the changes: https://turinglang.org/${repoName}/pr-previews/${prNumber}`;
+            github.issues.createComment({owner: repoOwner, repo: repoName, issue_number: prNumber, body: commentBody});

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -67,11 +67,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Delete PR Preview Branch
+      - name: Delete PR Preview Branch and Directory
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           BRANCH_NAME="pr-previews/${PR_NUMBER}"
-          git push origin --delete $BRANCH_NAME
+
+          # Delete the preview branch if it exists
+          git ls-remote --exit-code --heads origin $BRANCH_NAME && git push origin --delete $BRANCH_NAME || echo "Branch $BRANCH_NAME does not exist"
+
           # Remove preview directory from gh-pages
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,4 @@
-name: PR Docs Workflow
+name: PR Preview Workflow
 
 on:
   pull_request:
@@ -60,27 +60,22 @@ jobs:
           git commit -m "Deploy preview for PR #${PR_NUMBER}"
           git push
 
-  delete-preview-branch:
+  delete-preview-directory:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout gh-pages branch
         uses: actions/checkout@v4
+        with:
+          ref: gh-pages
 
-      - name: Delete PR Preview Branch and Directory
+      - name: Remove PR Preview Directory
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          BRANCH_NAME="pr-previews/${PR_NUMBER}"
-
-          # Delete the preview branch if it exists
-          git ls-remote --exit-code --heads origin $BRANCH_NAME && git push origin --delete $BRANCH_NAME || echo "Branch $BRANCH_NAME does not exist"
-
-          # Remove preview directory from gh-pages
+          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git clone --depth 1 --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
-          cd gh-pages
-          rm -rf pr-previews/${PR_NUMBER}
+          rm -rf ${PREVIEW_DIR}
           git add .
           git commit -m "Remove preview for merged PR #${PR_NUMBER}"
           git push

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,7 +61,7 @@ jobs:
           git push
 
   delete-preview-directory:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.action == 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,85 @@
+name: PR Docs Workflow
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+
+jobs:
+  build-and-preview:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: pre-release
+
+      - name: Restore cached _freeze folder
+        id: cache-primes-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            _freeze/
+          key: ${{ runner.os }}-primes-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-primes
+
+      - name: Render Quarto site
+        run: quarto render
+
+      - name: Save _freeze folder
+        id: cache-primes-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            _freeze/
+          key: ${{ runner.os }}-primes-${{ github.run_id }}
+
+      - name: Deploy Preview to GitHub Pages
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git clone --depth 1 --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+          mkdir -p gh-pages/${PREVIEW_DIR}
+          cp -r _site/* gh-pages/${PREVIEW_DIR}
+          cd gh-pages
+          git add .
+          git commit -m "Deploy preview for PR #${PR_NUMBER}"
+          git push
+
+  delete-preview-branch:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Delete PR Preview Branch
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          BRANCH_NAME="pr-previews/${PR_NUMBER}"
+          git push origin --delete $BRANCH_NAME
+          # Remove preview directory from gh-pages
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git clone --depth 1 --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+          cd gh-pages
+          rm -rf pr-previews/${PR_NUMBER}
+          git add .
+          git commit -m "Remove preview for merged PR #${PR_NUMBER}"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -83,7 +83,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   comment-preview-url:
-    if: always()
+    needs: build-and-preview
+    if: needs.build-and-preview.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Comment Preview URL

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,10 +60,6 @@ jobs:
           git commit -m "Deploy preview for PR #${PR_NUMBER}"
           git push
 
-      - name: Get PR number
-        id: get_pr_number
-        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
   delete-preview-directory:
     if: github.event.action == 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -87,20 +83,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   comment-preview-url:
-    needs: build-and-preview
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR number
-        run: echo "PR_NUMBER=${{ needs.build-and-preview.outputs.PR_NUMBER }}" >> $GITHUB_ENV
-
-      - name: Comment Preview URL
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = process.env.PR_NUMBER;
-            const repoOwner = context.repo.owner;
-            const repoName = context.repo.repo;
-            const commentBody = `Preview the changes: https://turinglang.org/${repoName}/pr-previews/${prNumber}`;
-            github.issues.createComment({owner: repoOwner, repo: repoName, issue_number: prNumber, body: commentBody});
+      - name: Print Preview URL
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO_NAME=${{ github.repository }}
+          echo "Preview URL: https://turinglang.org/$REPO_NAME/pr-previews/$PR_NUMBER"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -86,8 +86,19 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Print Preview URL
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          REPO_NAME=${{ github.repository }}
-          echo "Preview URL: https://turinglang.org/$REPO_NAME/pr-previews/$PR_NUMBER"
+      - name: Comment Preview URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repoName = context.repo.repo;
+            const previewUrl = `https://turinglang.org/${repoName}/pr-previews/${prNumber}`;
+            const commentBody = `Preview the changes: ${previewUrl}`;
+  
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            });


### PR DESCRIPTION
This PR includes a new workflow and it will:
- Render the latest commit and push the rendered site to the `pr-preview/pr-number` folder in the `gh-pages` branch
- Deletes the `pr-preview/pr-number` folder if:
    - PR is merged
    - PR is closed with or without a merge
- Comments the link where current PR's preview of the latest commit is visible only if 1st step succeeds