### PR TITLE
Fix two internal links

### DIFF
--- a/tutorials/docs-14-using-turing-quick-start/index.qmd
+++ b/tutorials/docs-14-using-turing-quick-start/index.qmd
@@ -13,9 +13,9 @@ Pkg.instantiate();
 
 If you are already well-versed in probabilistic programming and want to take a quick look at how Turing's syntax works or otherwise just want a model to start with, we have provided a complete Bayesian coin-flipping model below.
 
-This example can be run wherever you have Julia installed (see [Getting Started]({{< meta site-url >}}/dev/docs/using-turing/getting-started/), but you will need to install the packages `Turing` and `StatsPlots` if you have not done so already.
+This example can be run wherever you have Julia installed (see [Getting Started](../docs-00-getting-started/index.qmd), but you will need to install the packages `Turing` and `StatsPlots` if you have not done so already.
 
-This is an excerpt from a more formal example which can be found in the documentation website [here]({{< meta site-url >}}/dev/docs/tutorials/introduction/).
+This is an excerpt from a more formal example which can be found [here](../00-introduction/index.qmd).
 
 ## Import Libraries
 ```{julia}


### PR DESCRIPTION
I think the relative references are simpler, and for some reason at least one of the links was also broken when deployed in gh-pages.