### PR TITLE
Fix minor formatting issues in Gaussian process tutorial

### DIFF
--- a/tutorials/15-gaussian-processes/index.qmd
+++ b/tutorials/15-gaussian-processes/index.qmd
@@ -55,9 +55,11 @@ Observe it has three columns:
 We will use a Binomial model for the data, whose success probability is parametrised by a
 transformation of a GP. Something along the lines of:
 $$
-f \sim \operatorname{GP}(0, k) \\
-y_j \mid f(d_j) \sim \operatorname{Binomial}(n_j, g(f(d_j))) \\
-g(x) := \frac{1}{1 + e^{-x}}
+\begin{aligned}
+f & \sim \operatorname{GP}(0, k) \\
+y_j \mid f(d_j) & \sim \operatorname{Binomial}(n_j, g(f(d_j))) \\
+g(x) & := \frac{1}{1 + e^{-x}}
+\end{aligned}
 $$
 
 To do this, let's define our Turing.jl model:
@@ -79,10 +81,10 @@ We first define an `AbstractGPs.GP`, which represents a distribution over functi
 is entirely separate from Turing.jl.
 We place a prior over its variance `v` and length-scale `l`.
 `f(d, jitter)` constructs the multivariate Gaussian comprising the random variables
-in `f` whose indices are in `d` (+ a bit of independent Gaussian noise with variance
+in `f` whose indices are in `d` (plus a bit of independent Gaussian noise with variance
 `jitter` -- see [the docs](https://juliagaussianprocesses.github.io/AbstractGPs.jl/dev/api/#FiniteGP-and-AbstractGP)
 for more details).
-`f(d, jitter) isa AbstractMvNormal`, and is the bit of AbstractGPs.jl that implements the
+`f(d, jitter)` has the type `AbstractMvNormal`, and is the bit of AbstractGPs.jl that implements the
 Distributions.jl interface, so it's legal to put it on the right-hand side
 of a `~`.
 From this you should deduce that `f_latent` is distributed according to a multivariate
@@ -145,7 +147,7 @@ this example. See Turing.jl's docs on Automatic Differentiation for more info.
 using Random, ReverseDiff
 
 m_post = m | (y=df.y,)
-chn = sample(Xoshiro(123456), m_post, NUTS(;adtype=AutoReverseDiff()), 1_000, progress=false)
+chn = sample(Xoshiro(123456), m_post, NUTS(; adtype=AutoReverseDiff()), 1_000, progress=false)
 ```
 
 We can use these samples and the `posterior` function from `AbstractGPs` to sample from the


### PR DESCRIPTION
Fixing a couple of very minor formatting typos in `15-gaussian-processes`.