### PR TITLE
404 error file is linked to wrong links!

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -157,5 +157,5 @@ execute:
 # Global Variables to use in any qmd files using:
 # {{< meta site-url >}}
 site-url: https://turinglang.org/
-get-started: tutorials/docs-00-getting-started/
-tutorials-intro: tutorials/00-introduction/
+get-started: docs/tutorials/docs-00-getting-started/
+tutorials-intro: docs/tutorials/00-introduction/


### PR DESCRIPTION
404 error links are being served from root domain, so they need have `docs` at start!