### PR TITLE
broken urls fixed

### DIFF
--- a/tutorials/00-introduction/index.qmd
+++ b/tutorials/00-introduction/index.qmd
@@ -1,6 +1,9 @@
 ---
 title: Introduction to Turing
 engine: julia
+aliases: 
+  - ../
+  - ../../
 ---
 
 ```{julia}


### PR DESCRIPTION
`https://turinglang.org/docs/tutorials/` - this will work fine now and `https://turinglang.org/docs/` - this will redirect to first tutorial