### PR TITLE
Add restore key to _freeze cache key

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,7 +41,10 @@ jobs:
         with:
           path: |
             ./_freeze/
-          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
+          key: |
+            ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
 
       - name: Render Quarto site
         run: quarto render

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,10 @@ jobs:
         with:
           path: |
             ./_freeze/
-          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
+          key: |
+            ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
 
       - name: Extract version from _quarto.yml
         id: extract_version


### PR DESCRIPTION
This PR makes a tiny change to both preview and publish workflows:

https://github.com/TuringLang/docs/blob/d7dd920038893dee8fc9f29d552f397ec53ececd/.github/workflows/publish.yml#L40-L49

The main cache key itself will now be determined by both the Manifest as well as the contents of the notebooks (`**/index.qmd`). However, if the contents of the notebooks have changed, it will use the restore key to load the latest version of `_freeze` that was run with the same Manifest.

The aim is to let each CI run access the most recently cached `_freeze` folder, to avoid re-rendering the same docs page on successive CI runs.

Closes #536