### PR TITLE
Cache _freeze correctly

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: |
             ./_freeze/
-          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           path: |
             ./_freeze/
-          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
 
       - name: Fetch search_original.json from main site
         run: curl -O https://raw.githubusercontent.com/TuringLang/turinglang.github.io/gh-pages/search_original.json


### PR DESCRIPTION
Unbelievably, in #537 I managed to change the key that the cache was being loaded from, but didn't change the key that the cache was being saved to.

This fixes that oversight.