### PR TITLE
Add `import Pkg` for ease of copy-pasting

### DIFF
--- a/tutorials/docs-01-contributing-guide/index.qmd
+++ b/tutorials/docs-01-contributing-guide/index.qmd
@@ -27,16 +27,16 @@ Other sections of the website (anything that isn't a package, or a tutorial) –
 
 ### Tests
 
-Turing, like most software libraries, has a test suite. You can run the whole suite the usual Julia way with
+Turing, like most software libraries, has a test suite. You can run the whole suite by running `julia --project=.` from the root of the Turing repository, and then running
 
 ```julia
-Pkg.test("Turing")
+import Pkg; Pkg.test("Turing")
 ```
 
 The test suite subdivides into files in the `test` folder, and you can run only some of them using commands like
 
 ```julia
-Pkg.test("Turing"; test_args=["optim", "hmc", "--skip", "ext"])
+import Pkg; Pkg.test("Turing"; test_args=["optim", "hmc", "--skip", "ext"])
 ```
 
 This one would run all files with "optim" or "hmc" in their path, such as `test/optimisation/Optimisation.jl`, but not files with "ext" in their path. Alternatively, you can set these arguments as command line arguments when you run Julia


### PR DESCRIPTION
The docs on contributing say to run `Pkg.test`, but it's annoying to copy-paste this and get hit with Pkg not defined.

This fixes it so that the test command can be copied as a one-liner into a fresh Julia REPL.

Also specifies that you need to use `julia --project=.` from the top level, as I don't think there's any harm in being explicit.