### PR TITLE
Fix GHA stuff

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - synchronize
-      - closed
 
 concurrency:
   group: docs

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,10 @@ on:
 concurrency:
   group: docs
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build-and-preview:
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -70,12 +74,7 @@ jobs:
           commit-message: Deploy preview for PR ${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  comment-preview-url:
-    needs: build-and-preview
-    if: needs.build-and-preview.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment Preview URL
+      - name: Comment preview URL
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
@@ -83,28 +82,3 @@ jobs:
             Preview the changes: https://turinglang.org/docs/pr-previews/${{ github.event.pull_request.number }}
             Please avoid using the search feature and navigation bar in PR previews!
           comment_tag: preview-url-comment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  delete-preview-directory:
-    if: github.event.action == 'closed' || github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-    
-      - name: Remove PR Preview Directory
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git pull origin gh-pages
-          rm -rf ${PREVIEW_DIR}
-          git add .
-          git commit -m "Remove preview for merged PR #${PR_NUMBER}"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/remove_preview.yml
+++ b/.github/workflows/remove_preview.yml
@@ -1,0 +1,31 @@
+name: Remove PR previews
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  delete-preview-directory:
+    if: github.event.action == 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+    
+      - name: Remove PR Preview Directory
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git pull origin gh-pages
+          rm -rf ${PREVIEW_DIR}
+          git add .
+          git commit -m "Remove preview for merged PR #${PR_NUMBER}"
+          git push

--- a/.github/workflows/version_check.jl
+++ b/.github/workflows/version_check.jl
@@ -107,7 +107,12 @@ if ENV["TARGET_IS_MASTER"] == "true"
         println("$(MANIFEST_TOML_PATH) is out of date; updating")
         old_env = Pkg.project().path
         Pkg.activate(".")
-        Pkg.update()
+        try
+            Pkg.add(name="Turing", version=latest_version)
+        catch e
+            # If the Manifest couldn't be updated, the error will be shown later
+            println(e)
+        end
         # Check if versions match now, error if not
         Pkg.activate(old_env)
         manifest_toml = TOML.parsefile(MANIFEST_TOML_PATH)

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -51,12 +51,11 @@ jobs:
 
       - name: Check version consistency
         id: version_check
-        continue-on-error: true
         run: julia --color=yes .github/workflows/version_check.jl
 
       - name: Create a PR with suggested changes
         id: create_pr
-        if: steps.version_check.outcome == 'failure' && env.TARGET_IS_MASTER && (! env.IS_PR_FROM_FORK)
+        if: always() && steps.version_check.outcome == 'failure' && env.TARGET_IS_MASTER && (! env.IS_PR_FROM_FORK)
         uses: peter-evans/create-pull-request@v6
         with:
           base: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
@@ -66,7 +65,7 @@ jobs:
           title: "Update Turing.jl version to match latest release"
 
       - name: Comment on PR about suggested changes (if PR was made)
-        if: github.event_name == 'pull_request' && steps.create_pr.outputs.pull-request-operation == 'created'
+        if: always() && github.event_name == 'pull_request' && steps.create_pr.outputs.pull-request-operation == 'created'
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |


### PR DESCRIPTION
This PR makes a few changes to GitHub Actions workflows:

1. Separates the preview workflow from the remove-preview workflow.
   
   Whenever a PR was merged to master, the remove-preview workflow would fire. However, the publish workflow on master would also fire. The changes in #527 meant that the publish workflow would cancel the remove-preview workflow. The result is that we have a buildup of PR previews.
   
   This fixes it by making the remove-preview workflow a separate one entirely, so that its running is unaffected by other workflows.

2. Modifies the version check workflow to not use `continue-on-error: true`. This causes the workflow to always report a green tick, even if the step did have an error. Instead I use `always()` on the subsequent steps.

3. Slightly improves the version checking script.