### PR TITLE
Improve HMC sampler setup for faster convergence

### DIFF
--- a/tutorials/docs-12-using-turing-guide/index.qmd
+++ b/tutorials/docs-12-using-turing-guide/index.qmd
@@ -280,7 +280,7 @@ end
 
 # Construct a model with x = missing
 model = gdemo(missing)
-c = sample(model, HMC(0.01, 5), 500)
+c = sample(model, HMC(0.05, 20), 500)
 ```
 
 Note the need to initialize `x` when missing since we are iterating over its elements later in the model. The generated values for `x` can be extracted from the `Chains` object using `c[:x]`.


### PR DESCRIPTION
Fix https://github.com/TuringLang/docs/issues/569

We could have obtained better ESS and Rhat via NUTS, but the example is meant to demonstrate HMC. This PR improves the HMC setup to get better convergence. 