### PR TITLE
Cache _freeze and .julia even if docs fail to build

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,7 +29,8 @@ jobs:
           version: '1.11'
 
       - name: Load Julia packages from cache
-        uses: julia-actions/cache@v2
+        id: julia-cache
+        uses: penelopeysm/julia-cache@main
         with:
           cache-name: julia-cache;${{ hashFiles('**/Manifest.toml') }}
           delete-old-caches: false
@@ -57,11 +58,20 @@ jobs:
 
       - name: Save _freeze folder
         id: cache-save
+        if: always()
         uses: actions/cache/save@v4
         with:
           path: |
             ./_freeze/
           key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
+
+      - name: Save Julia depot cache
+        id: julia-cache-save
+        if: always() && steps.julia-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.julia-cache.outputs.cache-paths }}
+          key: ${{ steps.julia-cache.outputs.cache-key }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
Closes #590. This uses my fork of `julia-actions/cache` because I don't want to wait for the upstream PR to be merged. If it does get merged then we can always revert to the official version.