### PR TITLE
use !cancelled() instead of always() when caching stuff

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Save _freeze folder
         id: cache-save
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -67,7 +67,7 @@ jobs:
 
       - name: Save Julia depot cache
         id: julia-cache-save
-        if: always() && steps.julia-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.julia-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.julia-cache.outputs.cache-paths }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,11 @@ jobs:
           version: '1.11'
 
       - name: Load Julia packages from cache
-        uses: julia-actions/cache@v2
+        id: julia-cache
+        uses: penelopeysm/julia-cache@main
+        with:
+          cache-name: julia-cache;${{ hashFiles('**/Manifest.toml') }}
+          delete-old-caches: false
 
       # Note: needs resolve() to fix #518
       - name: Instantiate Julia environment
@@ -86,11 +90,20 @@ jobs:
 
       - name: Save _freeze folder
         id: cache-save
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v4
         with:
           path: |
             ./_freeze/
           key: ${{ runner.os }}-${{ hashFiles('**/Manifest.toml') }}-${{ hashFiles('**/index.qmd') }}
+
+      - name: Save Julia depot cache
+        id: julia-cache-save
+        if: ${{ !cancelled() && steps.julia-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.julia-cache.outputs.cache-paths }}
+          key: ${{ steps.julia-cache.outputs.cache-key }}
 
       - name: Fetch search_original.json from main site
         run: curl -O https://raw.githubusercontent.com/TuringLang/turinglang.github.io/gh-pages/search_original.json


### PR DESCRIPTION
see #590 and #591 for previous context

this pr changes it such that if the job is cancelled, the `_freeze` and `.julia` directories aren't cached. it now only caches if the step failed due to build errors. this avoids inadvertently caching stuff that hasn't even built yet (eg if the run was cancelled very early on)

also closes #594