### PR TITLE
Use julia-actions/cache again

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load Julia packages from cache
         id: julia-cache
-        uses: penelopeysm/julia-cache@main
+        uses: julia-actions/cache@v2
         with:
           cache-name: julia-cache;${{ hashFiles('**/Manifest.toml') }}
           delete-old-caches: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Load Julia packages from cache
         id: julia-cache
-        uses: penelopeysm/julia-cache@main
+        uses: julia-actions/cache@v2
         with:
           cache-name: julia-cache;${{ hashFiles('**/Manifest.toml') }}
           delete-old-caches: false


### PR DESCRIPTION
See https://github.com/TuringLang/docs/issues/590. The upstream PR https://github.com/julia-actions/cache/pull/169 was merged and released so we can now go back to using it :)