### PR TITLE
Don't display old AbstractMCMC notebooks in sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -199,8 +199,6 @@ dev-model-manual: developers/compiler/model-manual
 contexts: developers/compiler/minituring-contexts
 minituring: developers/compiler/minituring-compiler
 using-turing-compiler: developers/compiler/design-overview
-using-turing-abstractmcmc: developers/inference/abstractmcmc-turing
-using-turing-interface: developers/inference/abstractmcmc-interface
 using-turing-variational-inference: developers/inference/variational-inference
 using-turing-implementing-samplers: developers/inference/implementing-samplers
 dev-transforms-distributions: developers/transforms/distributions

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -105,11 +105,9 @@ website:
               - developers/transforms/bijectors/index.qmd
               - developers/transforms/dynamicppl/index.qmd
 
-          - section: "Inference (note: outdated)"
+          - section: "Inference in Detail"
             collapse-level: 1
             contents:
-              - developers/inference/abstractmcmc-interface/index.qmd
-              - developers/inference/abstractmcmc-turing/index.qmd
               - developers/inference/variational-inference/index.qmd
               - developers/inference/implementing-samplers/index.qmd
 


### PR DESCRIPTION
I think there are quite a few issues now complaining about the fact that the AbstractMCMC docs are out of date. (To be fair, they are several years out of date.)

The fastest way to fix these is to simply hide the tutorials. (Right now, they get displayed on the sidebar with a big notice saying 'out of date'. Why bother?)

I didn't delete the source code, because I suppose some of it might be useful for when it actually gets rewritten. (I think that also means that the URLs will still work -- because the notebooks will still be built -- they just won't be linked to in the sidebar.)
But the rewriting will have to wait for cleanup of some of Turing's codebase -- and that will take a while. I think this is a fine interim measure.

Closes #477 
Closes #517 

(Also 'closes' a bunch of other comments)