### PR TITLE
Update index.qmd with edge case for data-fitting

### DIFF
--- a/tutorials/bayesian-differential-equations/index.qmd
+++ b/tutorials/bayesian-differential-equations/index.qmd
@@ -113,7 +113,8 @@ To avoid this happening, we tell the solver to aim for small absolute and relati
 We also add a fudge factor `ϵ = 1e-5` to the predicted data.
 Since `ϵ` is greater than the solver's tolerance, it should overcome any remaining numerical error, making sure all predicted values are positive.
 At the same time, it is so small compared to the data that it should have a negligible effect on inference.
-If this approach doesn't work, there are some more ideas to try [here](https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#My-ODE-goes-negative-but-should-stay-positive,-what-tools-can-help?). In the case of continuous observations (e.g. deriving from modelling chemical reactions), it is sufficient to use a Normal distribution with the mean as the data point and an appropriately chosen variance (which can also be a parameter with a prior distribution).
+If this approach doesn't work, there are some more ideas to try [here](https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#My-ODE-goes-negative-but-should-stay-positive,-what-tools-can-help?).
+In the case of continuous observations (e.g. data derived from modelling chemical reactions), it is sufficient to use a normal distribution with the mean as the data point and an appropriately chosen variance (which can itself also be a parameter with a prior distribution).
 
 ```{julia}
 @model function fitlv(data, prob)

--- a/tutorials/bayesian-differential-equations/index.qmd
+++ b/tutorials/bayesian-differential-equations/index.qmd
@@ -82,6 +82,7 @@ To make the example more realistic, we generate data as random Poisson counts ba
 Poisson-distributed data are common in ecology (for instance, counts of animals detected by a camera trap).
 We'll assume that the rate $\lambda$, which parameterizes the Poisson distribution, is proportional to the underlying animal densities via a constant factor $q = 1.7$.
 
+
 ```{julia}
 sol = solve(prob, Tsit5(); saveat=0.1)
 q = 1.7
@@ -108,11 +109,11 @@ Practically, this helps us to illustrate the results without needing to run over
 Note we also have to take special care with the ODE solver.
 For certain parameter combinations, the numerical solver may predict animal densities that are just barely below zero.
 This causes errors with the Poisson distribution, which needs a non-negative mean $\lambda$.
-To avoid this happening, we tell the solver to aim for small abolute and relative errors (`abstol=1e-6, reltol=1e-6`).
+To avoid this happening, we tell the solver to aim for small absolute and relative errors (`abstol=1e-6, reltol=1e-6`).
 We also add a fudge factor `ϵ = 1e-5` to the predicted data.
 Since `ϵ` is greater than the solver's tolerance, it should overcome any remaining numerical error, making sure all predicted values are positive.
 At the same time, it is so small compared to the data that it should have a negligible effect on inference.
-If this approach doesn't work, there are some more ideas to try [here](https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#My-ODE-goes-negative-but-should-stay-positive,-what-tools-can-help?).
+If this approach doesn't work, there are some more ideas to try [here](https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#My-ODE-goes-negative-but-should-stay-positive,-what-tools-can-help?). In the case of continuous observations (e.g. deriving from modelling chemical reactions), it is sufficient to use a Normal distribution with the mean as the data point and an appropriately chosen variance (which can also be a parameter with a prior distribution).
 
 ```{julia}
 @model function fitlv(data, prob)


### PR DESCRIPTION
This case came from attempting to adapt the code to fitting experimental data to an ODE model derived from chemical equations. It turns out that using the Normal distribution is recommended in the general case according to one of my supervisors.