### PR TITLE
Update for Turing v0.48

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,12 +2,13 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "165c9b2e307ec4420cdb51ec5caec7c842dd9911"
+project_hash = "b4a761718945dc70cbfca75bb26db68fe2d9d3e7"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "629de23e1c16911b439dabd2303c08af9575b226"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.22.2"
+version = "1.24.0"
 weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
 
     [deps.ADTypes.extensions]
@@ -17,9 +18,9 @@ weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
 
 [[deps.AMD]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
-git-tree-sha1 = "45a1272e3f809d36431e57ab22703c6896b8908f"
+git-tree-sha1 = "344f3d221a6bee75925b5c97a30cfd870f12a138"
 uuid = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
-version = "0.5.3"
+version = "0.5.4"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -40,9 +41,9 @@ version = "0.5.24"
 
 [[deps.AbstractMCMC]]
 deps = ["BangBang", "ConsoleProgressMonitor", "Dates", "Distributed", "LogDensityProblems", "Logging", "LoggingExtras", "ProgressLogging", "Random", "StatsBase", "TerminalLoggers", "UUIDs"]
-git-tree-sha1 = "8ac6182431567907e0d5170bcac6dd48fa541f78"
+git-tree-sha1 = "328c7d50f307c66308a915abb20d9889e5aab48b"
 uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
-version = "5.15.1"
+version = "5.16.0"
 
     [deps.AbstractMCMC.extensions]
     AbstractMCMCOnlineStatsExt = "OnlineStats"
@@ -54,9 +55,9 @@ version = "5.15.1"
 
 [[deps.AbstractPPL]]
 deps = ["ADTypes", "AbstractMCMC", "Accessors", "BangBang", "DensityInterface", "JSON", "LinearAlgebra", "MacroTools", "OrderedCollections", "Random", "StatsBase"]
-git-tree-sha1 = "36615af672a8bbd9270d4d6f5991490922da39d3"
+git-tree-sha1 = "31fb177c9952267ac2dc54a44868cb768390e6ef"
 uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
-version = "0.15.4"
+version = "0.15.5"
 weakdeps = ["DiffResults", "DifferentiationInterface", "Distributions", "ForwardDiff", "Mooncake", "Test"]
 
     [deps.AbstractPPL.extensions]
@@ -108,9 +109,9 @@ weakdeps = ["SparseArrays", "StaticArrays"]
 
 [[deps.AdvancedHMC]]
 deps = ["AbstractMCMC", "ArgCheck", "DocStringExtensions", "IrrationalConstants", "LinearAlgebra", "LogDensityProblems", "LogDensityProblemsAD", "LogExpFunctions", "ProgressMeter", "Random", "Setfield", "Statistics", "StatsBase"]
-git-tree-sha1 = "877f5aa8559585d13429008116827ce4c37483fc"
+git-tree-sha1 = "230bc5a3a9cd4e2ddb9c7cb1e00f330c88f04e03"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.8.6"
+version = "0.8.7"
 
     [deps.AdvancedHMC.extensions]
     AdvancedHMCADTypesExt = "ADTypes"
@@ -142,16 +143,6 @@ version = "0.8.10"
     ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
     MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
     StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-
-[[deps.AdvancedPS]]
-deps = ["AbstractMCMC", "Distributions", "Random", "Random123", "Requires", "SSMProblems", "StatsFuns"]
-git-tree-sha1 = "d92dd3fb4cc2748860ae8d5dd1d324cf0715a53b"
-uuid = "576499cb-2369-40b2-a588-c64705576edc"
-version = "0.7.2"
-weakdeps = ["Libtask"]
-
-    [deps.AdvancedPS.extensions]
-    AdvancedPSLibtaskExt = "Libtask"
 
 [[deps.AdvancedVI]]
 deps = ["ADTypes", "AbstractPPL", "Accessors", "ChainRulesCore", "DiffResults", "Distributions", "DocStringExtensions", "FillArrays", "Functors", "LinearAlgebra", "LogDensityProblems", "Optimisers", "ProgressMeter", "Random", "StatsBase"]
@@ -195,9 +186,9 @@ version = "3.5.2+0"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra"]
-git-tree-sha1 = "75757da5d9f771ef5909fc84f81d2f9d24127315"
+git-tree-sha1 = "daf5b2aab5b1c1fdcb65b05883cdb4b18abac1b9"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.27.0"
+version = "7.30.1"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceAMDGPUExt = "AMDGPU"
@@ -209,6 +200,7 @@ version = "7.27.0"
     ArrayInterfaceChainRulesExt = "ChainRules"
     ArrayInterfaceFillArraysExt = "FillArrays"
     ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceGPUArraysCoreTrackerExt = ["GPUArraysCore", "Tracker"]
     ArrayInterfaceMetalExt = "Metal"
     ArrayInterfaceReverseDiffExt = "ReverseDiff"
     ArrayInterfaceSparseArraysExt = "SparseArrays"
@@ -230,6 +222,16 @@ version = "7.27.0"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
     Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.ArrayLayouts]]
+deps = ["FillArrays", "LinearAlgebra", "StaticArrays"]
+git-tree-sha1 = "e0b47732a192dd59b9d079a06d04235e2f833963"
+uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+version = "1.12.2"
+weakdeps = ["SparseArrays"]
+
+    [deps.ArrayLayouts.extensions]
+    ArrayLayoutsSparseArraysExt = "SparseArrays"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -258,6 +260,12 @@ deps = ["LinearAlgebra", "Random", "SparseArrays", "WoodburyMatrices"]
 git-tree-sha1 = "01b8ccb13d68535d73d2b0c23e39bd23155fb712"
 uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
 version = "1.1.0"
+
+[[deps.BFloat16s]]
+deps = ["LinearAlgebra", "Printf", "Random"]
+git-tree-sha1 = "e386db8b4753b42caac75ac81d0a4fe161a68a97"
+uuid = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+version = "0.6.1"
 
 [[deps.BangBang]]
 deps = ["Accessors", "ConstructionBase", "InitialValues", "LinearAlgebra"]
@@ -309,11 +317,6 @@ version = "0.16.2"
     Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
     ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
-[[deps.BitFlags]]
-git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
-uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
-version = "0.1.10"
-
 [[deps.BitTwiddlingConvenienceFunctions]]
 deps = ["Static"]
 git-tree-sha1 = "f21cfd4950cb9f0587d5067e69405ad2acd27b87"
@@ -350,9 +353,9 @@ version = "0.2.7"
 
 [[deps.CSV]]
 deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
-git-tree-sha1 = "8d8e0b0f350b8e1c91420b5e64e5de774c2f0f4d"
+git-tree-sha1 = "abed1e735dd4152f48c90cf0767e1790e25f332f"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.10.16"
+version = "0.10.17"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -410,9 +413,9 @@ weakdeps = ["Statistics"]
 
 [[deps.ChangesOfVariables]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "3aa4bf1532aa2e14e0374c4fd72bed9a9d0d0f6c"
+git-tree-sha1 = "83ee8183bd8c4a390ae178385e6c7b3aa4e468b2"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.10"
+version = "0.1.11"
 weakdeps = ["InverseFunctions", "Test"]
 
     [deps.ChangesOfVariables.extensions]
@@ -439,9 +442,9 @@ version = "3.0.2"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+git-tree-sha1 = "970758a3d591a2a5c2a907c53f2e2f8c1b1d3537"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.8"
+version = "0.7.9"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
@@ -476,9 +479,10 @@ uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.13.1"
 
 [[deps.CommonSolve]]
-git-tree-sha1 = "eeaad7cef88554c2fa56b5a3f71cfd5cb708c662"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "6c389fa857f6ca5a95474b52a52023fd77f24cb7"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.11"
+version = "0.2.14"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools"]
@@ -487,9 +491,10 @@ uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.1"
 
 [[deps.CommonWorldInvalidations]]
-git-tree-sha1 = "cde75cb34c9ee07b4c37981b0f32378d0dc19ffe"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "6600cd2b039cd07dd8043fd05b0ff2899d9da73b"
 uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
-version = "1.1.1"
+version = "1.2.1"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -516,15 +521,10 @@ weakdeps = ["InverseFunctions"]
     CompositionsBaseInverseFunctionsExt = "InverseFunctions"
 
 [[deps.ConcreteStructs]]
-git-tree-sha1 = "23a2ac1ab2a39460d4feecddf09b02e9019d6dd5"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "a72c3b5ce6d2a477f55b5c9b8756e91e695c67f6"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
-version = "0.2.6"
-
-[[deps.ConcurrentUtilities]]
-deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
-uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.5.1"
+version = "0.2.8"
 
 [[deps.ConsoleProgressMonitor]]
 deps = ["Logging", "ProgressMeter"]
@@ -555,9 +555,9 @@ uuid = "adafc99b-e345-5852-983c-f28acb93d879"
 version = "0.3.1"
 
 [[deps.Crayons]]
-git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+git-tree-sha1 = "54b76cbb40d9a0f5368c880725b2f141da77c94f"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.1.1"
+version = "4.2.0"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -572,9 +572,9 @@ version = "1.8.2"
 
 [[deps.DataStructures]]
 deps = ["OrderedCollections"]
-git-tree-sha1 = "6fb53a69613a0b2b68a0d12671717d307ab8b24e"
+git-tree-sha1 = "b0bc6d2cad1fed8b7fd59a1551a991cb3d2809e6"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.19.5"
+version = "0.19.6"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -663,9 +663,9 @@ version = "6.218.0"
 
 [[deps.DiffEqCallbacks]]
 deps = ["ConcreteStructs", "DataStructures", "DiffEqBase", "DifferentiationInterface", "LinearAlgebra", "Markdown", "PrecompileTools", "RecipesBase", "RecursiveArrayTools", "SciMLBase", "StaticArraysCore"]
-git-tree-sha1 = "7f3d38ff9555696c29d13da449e57745623ddd2a"
+git-tree-sha1 = "88cdec45374d53393bf88268102a2b018c897178"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.18.3"
+version = "4.19.2"
 weakdeps = ["Functors"]
 
     [deps.DiffEqCallbacks.extensions]
@@ -696,9 +696,9 @@ version = "1.16.0"
 
 [[deps.DifferentiationInterface]]
 deps = ["ADTypes", "LinearAlgebra"]
-git-tree-sha1 = "dbd46a5cd0e79a97438b0ebbec42e744e8f436fe"
+git-tree-sha1 = "0693d8b0a4608ff289d228ab4c598df5894845cd"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.7.20"
+version = "0.7.21"
 
     [deps.DifferentiationInterface.extensions]
     DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
@@ -749,9 +749,9 @@ version = "0.7.20"
 
 [[deps.DimensionalData]]
 deps = ["ConstructionBase", "DataAPI", "Dates", "Extents", "Interfaces", "IntervalSets", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "PrecompileTools", "Random", "Statistics", "TableTraits", "Tables"]
-git-tree-sha1 = "57bbee194533adaa755b5cae528eabdea5d05039"
+git-tree-sha1 = "3e5b58039d35b98f425446c099577d67633a7237"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
-version = "0.30.1"
+version = "0.30.2"
 
     [deps.DimensionalData.extensions]
     DimensionalDataAbstractFFTsExt = "AbstractFFTs"
@@ -812,9 +812,9 @@ version = "1.11.0"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "cd3c5ac74cd3923c8945c6a81518c46abd0e73a3"
+git-tree-sha1 = "a958ab3a40c755563f5e1405c0846cb0446bf19d"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.129"
+version = "0.25.131"
 weakdeps = ["ChainRulesCore", "DensityInterface", "SparseConnectivityTracer", "Test"]
 
     [deps.Distributions.extensions]
@@ -840,12 +840,13 @@ uuid = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 version = "3.6.1"
 
 [[deps.DynamicPPL]]
-deps = ["ADTypes", "AbstractMCMC", "AbstractPPL", "Accessors", "BangBang", "Bijectors", "Chairmarks", "Compat", "ConstructionBase", "Distributions", "DocStringExtensions", "FillArrays", "InteractiveUtils", "LinearAlgebra", "LogDensityProblems", "MacroTools", "OrderedCollections", "PartitionedDistributions", "PrecompileTools", "Preferences", "Printf", "Random", "Statistics", "Test"]
-git-tree-sha1 = "a2e804ee37d06ce0e1390f3bc195a8a8c24606f6"
+deps = ["ADTypes", "AbstractMCMC", "AbstractPPL", "Accessors", "BangBang", "Bijectors", "Chairmarks", "Compat", "ConstructionBase", "Distributions", "DocStringExtensions", "FillArrays", "InteractiveUtils", "LinearAlgebra", "LogDensityProblems", "LogExpFunctions", "MacroTools", "OrderedCollections", "PartitionedDistributions", "PrecompileTools", "Preferences", "Printf", "Random", "SpecialFunctions", "Statistics", "Test"]
+git-tree-sha1 = "e9ba7870f264dd456a4fc9d9d9b59670eff0698a"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.42.1"
+version = "0.42.11"
 
     [deps.DynamicPPL.extensions]
+    DynamicPPLBridgeStanExt = ["BridgeStan"]
     DynamicPPLComponentArraysExt = ["ComponentArrays"]
     DynamicPPLEnzymeCoreExt = ["EnzymeCore"]
     DynamicPPLForwardDiffExt = ["ForwardDiff"]
@@ -855,6 +856,7 @@ version = "0.42.1"
     DynamicPPLReverseDiffExt = ["ReverseDiff"]
 
     [deps.DynamicPPL.weakdeps]
+    BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
     ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
     EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
     ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -877,24 +879,28 @@ version = "1.0.7"
 
 [[deps.Enzyme]]
 deps = ["CEnum", "EnzymeCore", "Enzyme_jll", "GPUCompiler", "InteractiveUtils", "LLVM", "Libdl", "LinearAlgebra", "ObjectFile", "PrecompileTools", "Preferences", "Printf", "Random", "SparseArrays"]
-git-tree-sha1 = "5cd3db843fedb95aa30880f3c2eb392084977d9e"
+git-tree-sha1 = "0b11d39c3659bce5f83a3fc47020cc994e785392"
 uuid = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-version = "0.13.184"
+version = "0.13.200"
 
     [deps.Enzyme.extensions]
     EnzymeBFloat16sExt = "BFloat16s"
+    EnzymeCUDAExt = "CUDA"
     EnzymeChainRulesCoreExt = "ChainRulesCore"
     EnzymeGPUArraysCoreExt = "GPUArraysCore"
     EnzymeLogExpFunctionsExt = "LogExpFunctions"
+    EnzymeOrderedCollectionsExt = "OrderedCollections"
     EnzymeSpecialFunctionsExt = "SpecialFunctions"
     EnzymeStaticArraysExt = "StaticArrays"
 
     [deps.Enzyme.weakdeps]
     ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
     BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
     LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+    OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
     SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
@@ -910,9 +916,9 @@ weakdeps = ["Adapt", "ChainRulesCore"]
 
 [[deps.Enzyme_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "6ef5790b091d4d3a05164771dde619db07518883"
+git-tree-sha1 = "d2c552cb05ab0455fdb53ab40a905a1d8e4db2cd"
 uuid = "7cc45869-7501-5eee-bdea-0790c847d4ef"
-version = "0.0.282+0"
+version = "0.0.291+1"
 
 [[deps.EpollShim_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -920,17 +926,11 @@ git-tree-sha1 = "8a4be429317c42cfae6a7fc03c31bad1970c310d"
 uuid = "2702e6a9-849d-5ed8-8c21-79e8b8f9ee43"
 version = "0.0.20230411+1"
 
-[[deps.ExceptionUnwrapping]]
-deps = ["Test"]
-git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
-uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
-version = "0.1.11"
-
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e6c4a6407a949e79a9d3f249bf49e6987c80e01f"
+git-tree-sha1 = "f4d39eee89f1e58c26bf447f1d4156c0125d6838"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.8.2+0"
+version = "2.8.3+0"
 
 [[deps.ExponentialUtilities]]
 deps = ["Adapt", "ArrayInterface", "GPUArraysCore", "GenericSchur", "LinearAlgebra", "PrecompileTools", "Printf", "SparseArrays", "libblastrampoline_jll"]
@@ -943,14 +943,14 @@ weakdeps = ["StaticArrays"]
     ExponentialUtilitiesStaticArraysExt = "StaticArrays"
 
 [[deps.ExprTools]]
-git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
+git-tree-sha1 = "d2e49e7efd29719d6f28b891b0e0e159daa9d2b4"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.10"
+version = "0.1.11"
 
 [[deps.ExpressionExplorer]]
-git-tree-sha1 = "5f1c005ed214356bbe41d442cc1ccd416e510b7e"
+git-tree-sha1 = "678f8b7cd246ed441d29ca42a99f5f138be2ecac"
 uuid = "21656369-7473-754a-2065-74616d696c43"
-version = "1.1.4"
+version = "1.1.5"
 
 [[deps.ExproniconLite]]
 git-tree-sha1 = "c13f0b150373771b0fdc1713c97860f8df12e6c2"
@@ -981,10 +981,10 @@ uuid = "b86e33f2-c0db-4aa1-a6e0-ab43e668529e"
 version = "0.3.1"
 
 [[deps.FastBroadcast]]
-deps = ["ArrayInterface", "LinearAlgebra"]
-git-tree-sha1 = "52216cc6b2e5b11ac6623ff2398ac00faf1c6e42"
+deps = ["ArrayInterface", "LinearAlgebra", "PrecompileTools"]
+git-tree-sha1 = "c8f8eefadaa330d982bbf5e395c34e53a13ab668"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "1.3.4"
+version = "1.4.0"
 weakdeps = ["Polyester", "Static"]
 
     [deps.FastBroadcast.extensions]
@@ -1003,9 +1003,10 @@ uuid = "442a2c76-b920-505d-bb47-c5924d526838"
 version = "1.3.0"
 
 [[deps.FastPower]]
-git-tree-sha1 = "33a6dfb7ad41394b15e90c10c216181dba06cf15"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "3c7269c236978d434a16ebe99f9743b9d706270a"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
-version = "1.3.4"
+version = "1.5.0"
 
     [deps.FastPower.extensions]
     FastPowerEnzymeExt = "Enzyme"
@@ -1030,10 +1031,12 @@ deps = ["Pkg", "Requires", "UUIDs"]
 git-tree-sha1 = "6621fef488e496356c9c9625d0562c12a6070819"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.20.0"
-weakdeps = ["HTTP"]
 
     [deps.FileIO.extensions]
     HTTPExt = "HTTP"
+
+    [deps.FileIO.weakdeps]
+    HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates"]
@@ -1052,9 +1055,9 @@ version = "1.11.0"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "2f979084d1e13948a3352cf64a25df6bd3b4dca3"
+git-tree-sha1 = "5bad39456d9f0166184fce2248783dd9862645c1"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.16.0"
+version = "1.17.0"
 weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
@@ -1065,9 +1068,9 @@ weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
-git-tree-sha1 = "07e98e3f332ee60179813dd9cdf21412e3c0a96a"
+git-tree-sha1 = "5031f23e040bf17082e5b52422d77b5e844eefb1"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.32.0"
+version = "2.33.0"
 
     [deps.FiniteDiff.extensions]
     FiniteDiffBandedMatricesExt = "BandedMatrices"
@@ -1089,9 +1092,9 @@ version = "0.8.6"
 
 [[deps.FlexiChains]]
 deps = ["AbstractMCMC", "AbstractPPL", "DelimitedFiles", "DimensionalData", "DocStringExtensions", "LinearAlgebra", "MCMCDiagnosticTools", "OrderedCollections", "PrecompileTools", "Printf", "Random", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "4ab612beb43427268726add5d7be00cfd70c648d"
+git-tree-sha1 = "844fa0c4d78d1f8d09ac3933a239b4a05b31cb64"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.31"
+version = "0.6.38"
 
     [deps.FlexiChains.extensions]
     FlexiChainsAdvancedHMCExt = ["AdvancedHMC", "DimensionalData"]
@@ -1100,6 +1103,7 @@ version = "0.6.31"
     FlexiChainsInferenceObjectsExt = ["InferenceObjects", "DimensionalData", "OrderedCollections"]
     FlexiChainsMCMCChainsExt = ["MCMCChains", "OrderedCollections"]
     FlexiChainsMakieExt = ["Makie", "StatsBase", "KernelDensity"]
+    FlexiChainsMonteCarloMeasurementsExt = ["MonteCarloMeasurements", "OrderedCollections"]
     FlexiChainsPairPlotsExt = ["PairPlots", "Makie"]
     FlexiChainsPigeonsDynamicPPLExt = ["Pigeons", "DynamicPPL", "AbstractMCMC"]
     FlexiChainsPigeonsExt = ["Pigeons"]
@@ -1120,6 +1124,7 @@ version = "0.6.31"
     KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
     MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
     Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
     PairPlots = "43a3c2be-4208-490b-832a-a21dcd55d7da"
     Pigeons = "0eb8d820-af6a-4919-95ae-11206f830c31"
     PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
@@ -1141,9 +1146,9 @@ version = "1.3.7"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
-git-tree-sha1 = "2c5d0b0e12088cde2cf84afb2784415b1ea3dfee"
+git-tree-sha1 = "1b86cca764a61dcac4fef4c5e16e378e5ed6953c"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.1"
+version = "1.4.5"
 weakdeps = ["StaticArrays"]
 
     [deps.ForwardDiff.extensions]
@@ -1172,10 +1177,10 @@ uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 version = "1.1.3"
 
 [[deps.FunctionWrappersWrappers]]
-deps = ["FunctionWrappers", "PrecompileTools", "TruncatedStacktraces"]
-git-tree-sha1 = "70a6ddcf65ee666a6873ba4bf1b02dc721474b38"
+deps = ["FunctionWrappers", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "2bcce3ad6f6977d617928d7707fdc86ac83cce03"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
-version = "1.10.1"
+version = "1.13.0"
 weakdeps = ["Enzyme", "EnzymeCore", "Mooncake"]
 
     [deps.FunctionWrappersWrappers.extensions]
@@ -1184,9 +1189,9 @@ weakdeps = ["Enzyme", "EnzymeCore", "Mooncake"]
 
 [[deps.Functors]]
 deps = ["Compat", "ConstructionBase", "LinearAlgebra", "Random"]
-git-tree-sha1 = "60a0339f28a233601cb74468032b5c302d5067de"
+git-tree-sha1 = "1ac2813982db52b974c9343124ca61adbf297316"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.5.2"
+version = "0.5.3"
 
 [[deps.Future]]
 deps = ["Random"]
@@ -1195,9 +1200,9 @@ version = "1.11.0"
 
 [[deps.GLFW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "libdecor_jll", "xkbcommon_jll"]
-git-tree-sha1 = "9e0fb9e54594c47f278d75063980e43066e26e20"
+git-tree-sha1 = "64bbbb7d1499297751b536dd39c58b20750ab1db"
 uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
-version = "3.4.1+1"
+version = "3.5.1+0"
 
 [[deps.GLM]]
 deps = ["Distributions", "LinearAlgebra", "LogExpFunctions", "Printf", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsModels"]
@@ -1223,10 +1228,10 @@ version = "1.23.0"
     NVPTX_LLVM_Backend_jll = "ef6e0fe3-e6ef-59c0-bde6-4989574699e0"
 
 [[deps.GR]]
-deps = ["Artifacts", "Base64", "DelimitedFiles", "Downloads", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Preferences", "Printf", "Qt6Wayland_jll", "Random", "Serialization", "Sockets", "TOML", "Tar", "Test", "p7zip_jll"]
-git-tree-sha1 = "f954322d5de03ec630d177cda203dcd92b6be399"
+deps = ["Artifacts", "Base64", "DelimitedFiles", "Downloads", "GR_jll", "JSON", "Libdl", "LinearAlgebra", "Preferences", "Printf", "Qt6Wayland_jll", "Random", "Serialization", "Sockets", "TOML", "Tar", "Test", "p7zip_jll"]
+git-tree-sha1 = "4d777f73c46b46b8b5276206059cf8a195499314"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.73.26"
+version = "0.73.27"
 
     [deps.GR.extensions]
     IJuliaExt = "IJulia"
@@ -1236,9 +1241,9 @@ version = "0.73.26"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "FreeType2_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Qt6Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "6fada551286ab6ea4ca1628cb2de9f166a2ec966"
+git-tree-sha1 = "f8eb8f7ba13ea75083531647fc8faeda8d541f07"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.73.26+0"
+version = "0.73.27+0"
 
 [[deps.Gamma]]
 git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
@@ -1246,10 +1251,10 @@ uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
 version = "1.1.0"
 
 [[deps.GenericSchur]]
-deps = ["LinearAlgebra", "Printf"]
-git-tree-sha1 = "a694e2a57394e409f7a11ee0977362a9fafcb8c7"
+deps = ["LinearAlgebra", "MatrixFactorizations", "Preferences", "Printf", "UUIDs"]
+git-tree-sha1 = "e3d1202ab9ae72edd4c46134ecbb6746ec420486"
 uuid = "c145ed77-6b09-5dd9-b285-bf645a82121e"
-version = "0.5.6"
+version = "0.5.8"
 
 [[deps.GettextRuntime_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll"]
@@ -1265,9 +1270,9 @@ version = "9.55.1+0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
+git-tree-sha1 = "090526e65de8f69648ac156daae153de8b56df62"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.86.3+0"
+version = "2.88.3+0"
 
 [[deps.Graphite2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1275,22 +1280,11 @@ git-tree-sha1 = "69ffb934a5c5b7e086a0b4fee3427db2556fba6e"
 uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
 version = "1.3.16+0"
 
-[[deps.Grisu]]
-git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
-uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
-version = "1.0.2"
-
-[[deps.HTTP]]
-deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.11.0"
-
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
-git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
+git-tree-sha1 = "c3f99f8e7c98031b8845ece9db86dca713ab9bf8"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "8.5.1+0"
+version = "100.14003.0+0"
 
 [[deps.HashArrayMappedTries]]
 git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
@@ -1309,15 +1303,15 @@ weakdeps = ["Distributions"]
 
 [[deps.HypergeometricFunctions]]
 deps = ["Gamma", "LinearAlgebra"]
-git-tree-sha1 = "18d7deab5fb0440dc6a7b6993c5c27b25420de10"
+git-tree-sha1 = "31bb6c92405c084617facc1d7ed9eb6c402d061e"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.29"
+version = "0.3.30"
 
 [[deps.IRTools]]
 deps = ["InteractiveUtils", "MacroTools"]
-git-tree-sha1 = "ae3dae80f39426a5e598374e929522285e6ba8d0"
+git-tree-sha1 = "88d07a6b68b8fffb13cacd49e23ea73c571859b2"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.4.17"
+version = "0.4.20"
 
 [[deps.IfElse]]
 git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
@@ -1330,9 +1324,9 @@ uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 version = "0.3.1"
 
 [[deps.InlineStrings]]
-git-tree-sha1 = "8f3d257792a522b4601c24a577954b0a8cd7334d"
+git-tree-sha1 = "06b65886c7577a3784d616e29f1302c2e36e389d"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.4.5"
+version = "1.4.6"
 
     [deps.InlineStrings.extensions]
     ArrowTypesExt = "ArrowTypes"
@@ -1343,9 +1337,9 @@ version = "1.4.5"
     Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [[deps.IntegerMathUtils]]
-git-tree-sha1 = "4c1acff2dc6b6967e7e750633c50bc3b8d83e617"
+git-tree-sha1 = "c72458f1962faeb003bf23cbdb75164fe6280906"
 uuid = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
-version = "0.1.3"
+version = "0.1.4"
 
 [[deps.IntelOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
@@ -1427,9 +1421,9 @@ version = "1.8.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+git-tree-sha1 = "c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.6.1"
+version = "1.7.1"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
@@ -1445,9 +1439,9 @@ version = "0.2.1"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1dae3057da6f2b9c857afef03177bbdc7c4afe92"
+git-tree-sha1 = "037babc10853eeb8e585418922246cb97b8e5b74"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.2.0+0"
+version = "3.2.0+1"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
@@ -1475,9 +1469,9 @@ version = "0.10.67"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
-git-tree-sha1 = "fc2e5bc665dfa1be33fac60b5762d462bccfae7b"
+git-tree-sha1 = "71e740d00d71cdb15145d7fe0d6000ec70534598"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.10.8"
+version = "0.10.9"
 
 [[deps.LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1493,21 +1487,19 @@ version = "4.1.0+0"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "PrecompileTools", "Preferences", "Printf", "Unicode"]
-git-tree-sha1 = "f74a9668f02e33399baa5ed3a092b3f7a93f192e"
+git-tree-sha1 = "d4bfee24427f4f441bd9212a107e375c39663aab"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.10.0"
+version = "9.13.1"
+weakdeps = ["BFloat16s"]
 
     [deps.LLVM.extensions]
     BFloat16sExt = "BFloat16s"
 
-    [deps.LLVM.weakdeps]
-    BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
-
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "70c96f133c78c3cdc06234157144fab3744c6b38"
+git-tree-sha1 = "d77aea19c9a71059a021acd99b0a4343e9661d94"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.43+1"
+version = "0.0.47+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1516,15 +1508,15 @@ uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
 version = "22.1.7+0"
 
 [[deps.LaTeXStrings]]
-git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+git-tree-sha1 = "f88f3ccef05a6a72a0cf0ed417c8fd68530f4ab2"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.4.0"
+version = "1.4.1"
 
 [[deps.Latexify]]
 deps = ["Format", "Ghostscript_jll", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
-git-tree-sha1 = "44f93c47f9cd6c7e431f2f2091fcba8f01cd7e8f"
+git-tree-sha1 = "df7566479bd64f20bd16b09960145e70160ffb3b"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.16.10"
+version = "0.16.12"
 
     [deps.Latexify.extensions]
     DataFramesExt = "DataFrames"
@@ -1557,9 +1549,9 @@ version = "0.1.3"
 
 [[deps.LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
-git-tree-sha1 = "95ba48564903b43b2462318aa243ee79d81135ff"
+git-tree-sha1 = "d4816abce26971e3237b46a47b99991f306e4832"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
-version = "0.2.1"
+version = "0.3.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -1622,9 +1614,9 @@ version = "2.42.0+0"
 
 [[deps.Libtask]]
 deps = ["MistyClosures", "Test"]
-git-tree-sha1 = "188e6364a7bb87f21e37b7545e13ab204614edf0"
+git-tree-sha1 = "d045ad5c965fc46c5d4c459d19a99271887de0e9"
 uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
-version = "0.9.18"
+version = "0.9.19"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
@@ -1640,9 +1632,9 @@ version = "2.42.0+0"
 
 [[deps.LineSearch]]
 deps = ["ADTypes", "CommonSolve", "ConcreteStructs", "FastClosures", "LinearAlgebra", "MaybeInplace", "PrecompileTools", "SciMLBase", "SciMLJacobianOperators", "StaticArraysCore"]
-git-tree-sha1 = "0ddc77c97e42b3024a1646278bdaafee0bd61583"
+git-tree-sha1 = "2e05027f5a68891d997fcad60d11ce48d09208d0"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
-version = "0.1.12"
+version = "0.1.14"
 weakdeps = ["LineSearches"]
 
     [deps.LineSearch.extensions]
@@ -1650,9 +1642,9 @@ weakdeps = ["LineSearches"]
 
 [[deps.LineSearches]]
 deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Printf"]
-git-tree-sha1 = "cef1ba655e8c1f65af9d96c4fffe18bf1a3a3291"
+git-tree-sha1 = "b4f9762e3ad693626ffd51ae4be359c0a7b08469"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.7.1"
+version = "7.8.1"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
@@ -1991,9 +1983,9 @@ version = "1.12.1"
 
 [[deps.MLUtils]]
 deps = ["ChainRulesCore", "CodeTracking", "Compat", "DataAPI", "DelimitedFiles", "Distributed", "InteractiveUtils", "MLCore", "Mmap", "NNlib", "Random", "ShowCases", "SimpleTraits", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "cbaae75c0473c1650f472ca6ed1ec7fc09153b75"
+git-tree-sha1 = "0a589dc0ada20d30b7e9ad13752cf25361875bf2"
 uuid = "f1d291b0-491e-4a28-83b9-f70985020b54"
-version = "0.4.12"
+version = "0.4.13"
 
 [[deps.MacroTools]]
 git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
@@ -2015,21 +2007,27 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
+[[deps.MatrixFactorizations]]
+deps = ["ArrayLayouts", "LinearAlgebra", "Printf", "Random"]
+git-tree-sha1 = "3bb3cf4685f1c90f22883f4c4bb6d203fa882b79"
+uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
+version = "3.1.3"
+
+    [deps.MatrixFactorizations.extensions]
+    MatrixFactorizationsBandedMatricesExt = "BandedMatrices"
+
+    [deps.MatrixFactorizations.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+
 [[deps.MaybeInplace]]
-deps = ["ArrayInterface", "LinearAlgebra", "MacroTools"]
-git-tree-sha1 = "ff492a386f370c79f73232c276a1729f5e841b78"
+deps = ["ArrayInterface", "LinearAlgebra", "MacroTools", "PrecompileTools"]
+git-tree-sha1 = "f2cde0ae772162f20287b803e623966d0d94dea9"
 uuid = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
-version = "0.1.6"
+version = "0.1.8"
 weakdeps = ["SparseArrays"]
 
     [deps.MaybeInplace.extensions]
     MaybeInplaceSparseArraysExt = "SparseArrays"
-
-[[deps.MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
-git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.1.10"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2064,15 +2062,16 @@ version = "0.8.1"
 
 [[deps.Mooncake]]
 deps = ["ADTypes", "ChainRulesCore", "DispatchDoctor", "ExprTools", "LinearAlgebra", "MistyClosures", "PrecompileTools", "Random", "Test"]
-git-tree-sha1 = "3ea8f8621f3df438bbe082b15105cc4489044388"
+git-tree-sha1 = "c639c9891bc1687dee5f91b92b8b2cfec882f7fc"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
-version = "0.5.38"
+version = "0.5.51"
 
     [deps.Mooncake.extensions]
     MooncakeAllocCheckExt = "AllocCheck"
     MooncakeBFloat16sExt = "BFloat16s"
-    MooncakeCUDAExt = "CUDA"
+    MooncakeCUDAExt = ["CUDA", "Statistics"]
     MooncakeChainRulesExt = "ChainRules"
+    MooncakeDistancesExt = "Distances"
     MooncakeDistributionsExt = "Distributions"
     MooncakeDynamicExpressionsExt = "DynamicExpressions"
     MooncakeFluxExt = "Flux"
@@ -2091,6 +2090,7 @@ version = "0.5.38"
     BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
     CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
     ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
     Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
     DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
     Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -2104,13 +2104,14 @@ version = "0.5.38"
     SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
     SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
     Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
     cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [[deps.Moshi]]
 deps = ["ExproniconLite", "Jieko"]
-git-tree-sha1 = "2d5d1195e4d29712c0db4c0b608c1c3467ab9428"
+git-tree-sha1 = "60beb0717782a3bbe0f7df56decad0ef89048c23"
 uuid = "2e0e35c7-a2e4-4343-998d-7ef72827ed2d"
-version = "0.3.11"
+version = "0.3.12"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
@@ -2118,21 +2119,21 @@ version = "2023.12.12"
 
 [[deps.MuladdMacro]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+git-tree-sha1 = "283bf85d4a767481dd924dff0eee1735e95f449e"
 uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.6"
+version = "0.2.7"
 
 [[deps.MultivariateStats]]
 deps = ["Arpack", "Distributions", "LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI", "StatsBase"]
-git-tree-sha1 = "7c3ff68a904d0f7404e5d2f7f5bc667934d8d616"
+git-tree-sha1 = "8bcdc90d5c361a73635ad1c19d9c39a52bf3e0a3"
 uuid = "6f286f6a-111f-5878-ab1e-185364afe411"
-version = "0.10.4"
+version = "0.10.5"
 
 [[deps.NLSolversBase]]
 deps = ["ADTypes", "DifferentiationInterface", "FiniteDiff", "LinearAlgebra"]
-git-tree-sha1 = "b3f76b463c7998473062992b246045e6961a074e"
+git-tree-sha1 = "f96d38936d92d610318dec4d3b5ef37b0373c20f"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "8.0.0"
+version = "8.0.1"
 
 [[deps.NLopt]]
 deps = ["CEnum", "NLopt_jll"]
@@ -2153,10 +2154,10 @@ uuid = "079eb43e-fd8e-5478-9966-2cf3e3edb778"
 version = "2.11.0+0"
 
 [[deps.NNlib]]
-deps = ["Adapt", "Atomix", "ChainRulesCore", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "Random", "ScopedValues", "Statistics"]
-git-tree-sha1 = "446a44652d12ea0a70cbb6f7a9a00ca314ad784a"
+deps = ["Adapt", "Atomix", "BFloat16s", "ChainRulesCore", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "Random", "ScopedValues", "Statistics"]
+git-tree-sha1 = "d450844d195714a2d29b38c231193c0297cf90e8"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.9.38"
+version = "0.9.45"
 
     [deps.NNlib.extensions]
     NNlibAMDGPUExt = "AMDGPU"
@@ -2324,17 +2325,11 @@ deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.5+0"
 
-[[deps.OpenSSL]]
-deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
-git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
-uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-version = "1.6.1"
-
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d8cce34295c55f47be683580f44791716045b8fe"
+git-tree-sha1 = "7787087cbc5ec110986e94d9aa1f17639a79c5de"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.7+0"
+version = "3.5.8+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -2344,9 +2339,9 @@ version = "0.5.6+0"
 
 [[deps.Optim]]
 deps = ["ADTypes", "EnumX", "FillArrays", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "PositiveFactorizations", "Printf", "SparseArrays", "Statistics"]
-git-tree-sha1 = "6fe140aab6c042a73c9d5dc280b87b32eee44f9f"
+git-tree-sha1 = "ece78ffe4fcee487b858ecaf184b8d7c2a79e015"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "2.2.1"
+version = "2.3.1"
 
     [deps.Optim.extensions]
     OptimMOIExt = "MathOptInterface"
@@ -2355,32 +2350,34 @@ version = "2.2.1"
     MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [[deps.Optimisers]]
-deps = ["ChainRulesCore", "ConstructionBase", "Functors", "LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "36b5d2b9dd06290cd65fcf5bdbc3a551ed133af5"
+deps = ["ChainRulesCore", "Compat", "ConstructionBase", "Functors", "LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "b6a586b581eccc60a181145ffd4382099e32e2df"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
-version = "0.4.7"
+version = "0.4.9"
 
     [deps.Optimisers.extensions]
     OptimisersAdaptExt = ["Adapt"]
     OptimisersEnzymeCoreExt = "EnzymeCore"
     OptimisersReactantExt = "Reactant"
+    OptimisersReactantMLDataDevicesExt = ["Reactant", "MLDataDevices"]
 
     [deps.Optimisers.weakdeps]
     Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
     EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
     Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 
 [[deps.Optimization]]
 deps = ["ADTypes", "ArrayInterface", "ConsoleProgressMonitor", "DocStringExtensions", "LinearAlgebra", "Logging", "LoggingExtras", "OptimizationBase", "Printf", "Reexport", "SciMLBase", "SparseArrays", "TerminalLoggers"]
-git-tree-sha1 = "91e05286c6460f23cde0feecf509433c0721f6ba"
+git-tree-sha1 = "2a7b377ca40f17db759d079f5368571ffe10f6c5"
 uuid = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
-version = "5.6.5"
+version = "5.7.0"
 
 [[deps.OptimizationBase]]
-deps = ["ADTypes", "ArrayInterface", "DifferentiationInterface", "DocStringExtensions", "FastClosures", "LinearAlgebra", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "SymbolicIndexingInterface"]
-git-tree-sha1 = "f19c70efa08caa57c794a1a7f0da549b8aa7a656"
+deps = ["ADTypes", "ArrayInterface", "DifferentiationInterface", "DocStringExtensions", "FastClosures", "LinearAlgebra", "PrecompileTools", "SciMLBase", "SciMLLogging", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "SymbolicIndexingInterface"]
+git-tree-sha1 = "37e44c9a2b0fadf55a57de550c9a06c35d3a1793"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.1"
+version = "5.3.0"
 
     [deps.OptimizationBase.extensions]
     OptimizationChainRulesCoreExt = "ChainRulesCore"
@@ -2407,16 +2404,16 @@ version = "5.2.1"
     Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [[deps.OptimizationNLopt]]
-deps = ["NLopt", "OptimizationBase", "Random", "Reexport", "SciMLBase"]
-git-tree-sha1 = "044f14c6718af4a792db9b7f6eb77d243bdac69b"
+deps = ["NLopt", "OptimizationBase", "Random", "Reexport", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "f39f875caa7ec66e507aea2f7e79f9e4f4e663c5"
 uuid = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
-version = "0.3.13"
+version = "0.3.15"
 
 [[deps.OptimizationOptimJL]]
 deps = ["Optim", "OptimizationBase", "Reexport", "SciMLBase", "SparseArrays"]
-git-tree-sha1 = "2ff86400fbc94d3012f1f9b66326161935b1de2d"
+git-tree-sha1 = "7a94b863f99a30bde3a36a3d2d6292f987cea743"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
-version = "0.4.16"
+version = "0.4.18"
 
 [[deps.Opus_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2631,9 +2628,9 @@ version = "10.42.0+1"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "26766d4b5f1a410c218a19b85a672c6edb693c65"
+git-tree-sha1 = "123266c25174ef6c8d4718920abc206452cf8de6"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.40"
+version = "0.11.41"
 weakdeps = ["StatsBase"]
 
     [deps.PDMats.extensions]
@@ -2641,21 +2638,21 @@ weakdeps = ["StatsBase"]
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
+git-tree-sha1 = "1912a9f1b9ca55005b03ba075f8e19993583e237"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.57.1+0"
+version = "1.58.2+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+git-tree-sha1 = "ba0dc8a8a67cacac4842631f960c046e4e563675"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.6"
+version = "2.8.8"
 
 [[deps.PartitionedDistributions]]
 deps = ["Distributions", "FillArrays", "InvertedIndices", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "PDMats", "SpecialFunctions", "StatsBase"]
-git-tree-sha1 = "5ea8f2735c0daeba35af6b879487e98f4e797093"
+git-tree-sha1 = "621944b594bec8df388aeecd2d694824cbe71ecd"
 uuid = "569bd051-8d7b-4221-bcb8-d78512b5866a"
-version = "0.0.1"
+version = "0.1.0"
 
 [[deps.Pixman_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
@@ -2686,9 +2683,9 @@ version = "1.4.4"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "TOML", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "cb20a4eacda080e517e4deb9cfb6c7c518131265"
+git-tree-sha1 = "83bd514e8ff16b5858ac54c53fa0bcf6002a3b00"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.41.6"
+version = "1.41.7"
 
     [deps.Plots.extensions]
     FileIOExt = "FileIO"
@@ -2706,9 +2703,9 @@ version = "1.41.6"
 
 [[deps.PoissonRandom]]
 deps = ["LogExpFunctions", "PrecompileTools", "Random"]
-git-tree-sha1 = "f58536f8611493685044a82adc73baab36c867e2"
+git-tree-sha1 = "faa278c0dc901606775554f6171350ad962d0e18"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.12"
+version = "0.4.13"
 
 [[deps.Polyester]]
 deps = ["ArrayInterface", "BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "ManualMemory", "PolyesterWeave", "Static", "StaticArrayInterface", "StrideArraysCore", "ThreadingUtilities"]
@@ -2735,17 +2732,16 @@ uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
 version = "0.2.4"
 
 [[deps.PreallocationTools]]
-deps = ["Adapt", "ArrayInterface", "PrecompileTools"]
-git-tree-sha1 = "920abd8738c02528d1078885e07bbd57939fc949"
+deps = ["Adapt", "ArrayInterface", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "cd00e28071a75c98664663f87c2ae447d25c0503"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "1.3.0"
-weakdeps = ["EnzymeCore", "ForwardDiff", "ReverseDiff", "SparseConnectivityTracer"]
+version = "1.7.1"
+weakdeps = ["EnzymeCore", "ForwardDiff", "ReverseDiff"]
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsEnzymeCoreExt = "EnzymeCore"
     PreallocationToolsForwardDiffExt = "ForwardDiff"
     PreallocationToolsReverseDiffExt = "ReverseDiff"
-    PreallocationToolsSparseConnectivityTracerExt = "SparseConnectivityTracer"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
@@ -2761,9 +2757,9 @@ version = "1.5.2"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "ebf455bb866ee6737030e3d3816bb6a0683c4325"
+git-tree-sha1 = "1b8aa19f229b1cea7fc93874a52e49db6a854450"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "3.4.0"
+version = "3.4.8"
 
     [deps.PrettyTables.extensions]
     PrettyTablesExcelExt = "XLSX"
@@ -2802,10 +2798,10 @@ uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 version = "1.4.0"
 
 [[deps.PureKLU]]
-deps = ["LinearAlgebra", "MuladdMacro", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "c24613c5ca510086fb22fe891d48d8969839dae1"
+deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
+git-tree-sha1 = "ef341b8e734ffa12c0464a58ca1c8a214d7a4235"
 uuid = "0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
-version = "1.1.1"
+version = "1.4.1"
 weakdeps = ["ForwardDiff"]
 
     [deps.PureKLU.extensions]
@@ -2973,10 +2969,10 @@ uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.1"
 
 [[deps.ResettableStacks]]
-deps = ["StaticArrays"]
-git-tree-sha1 = "f3ce73d334682818b8bd170145c2e4f666f1bd9d"
+deps = ["PrecompileTools", "StaticArrays"]
+git-tree-sha1 = "ed16b7ff60555aa33a8013b9a165c404da3685b3"
 uuid = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
-version = "1.2.3"
+version = "1.4.0"
 
 [[deps.ReverseDiff]]
 deps = ["ChainRulesCore", "DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
@@ -2992,15 +2988,15 @@ version = "0.9.0"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+git-tree-sha1 = "6d40b2fe70437b01397d2a4d5b020008da4e7019"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.5.1+0"
+version = "0.5.2+0"
 
 [[deps.Roots]]
 deps = ["Accessors", "CommonSolve", "Printf"]
-git-tree-sha1 = "125cbd31a56de53169c3eed9c17180bc6c245f83"
+git-tree-sha1 = "4db094d5e079abbda658acfe1c4d098430417717"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "3.0.4"
+version = "3.0.8"
 
     [deps.Roots.extensions]
     RootsChainRulesCoreExt = "ChainRulesCore"
@@ -3019,10 +3015,10 @@ version = "3.0.4"
     Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.RuntimeGeneratedFunctions]]
-deps = ["ExprTools", "SHA", "Serialization"]
-git-tree-sha1 = "0e3eba2ca347b001baade9fb830623e04da64b38"
+deps = ["ExprTools", "PrecompileTools", "SHA", "Serialization"]
+git-tree-sha1 = "6cb9b83354089fcb33c643773acfd3235f2f1bf5"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
-version = "0.5.22"
+version = "0.5.25"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -3033,17 +3029,11 @@ git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
 uuid = "94e857df-77ce-4151-89e5-788b33177be4"
 version = "0.1.0"
 
-[[deps.SSMProblems]]
-deps = ["AbstractMCMC", "Distributions", "Random"]
-git-tree-sha1 = "cbf723e4c486375cf91236db53a7beefe8291951"
-uuid = "26aad666-b158-4e64-9d35-0e672562fa48"
-version = "0.6.1"
-
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLLogging", "SciMLOperators", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "a017ed325ac5e11438c888864fe83b124bb171b7"
+git-tree-sha1 = "d56cb3b924cdf9297c171113e6a6ae9694e370eb"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.155.1"
+version = "2.155.2"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -3086,9 +3076,9 @@ version = "2.155.1"
 
 [[deps.SciMLJacobianOperators]]
 deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DifferentiationInterface", "FastClosures", "LinearAlgebra", "SciMLBase", "SciMLOperators"]
-git-tree-sha1 = "32927d7d411cf7318cef1276cfc8fd2edec8ea69"
+git-tree-sha1 = "ad167d716fc134c0873c76ba0469ede56a678732"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.15"
+version = "0.1.17"
 
 [[deps.SciMLLogging]]
 deps = ["Logging", "LoggingExtras", "Preferences"]
@@ -3101,25 +3091,24 @@ weakdeps = ["Tracy"]
     SciMLLoggingTracyExt = "Tracy"
 
 [[deps.SciMLOperators]]
-deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "6727e42481434c5e72574e7957c4a97e70ee3c6a"
+deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "0b5b895913f1269a8c80b59435c61d5a7d79970c"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.24.3"
+version = "1.30.0"
 
     [deps.SciMLOperators.extensions]
     SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
     SciMLOperatorsSparseArraysExt = "SparseArrays"
-    SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
     [deps.SciMLOperators.weakdeps]
     LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [[deps.SciMLPublic]]
-git-tree-sha1 = "24ff31136f3f991b74fbef71d5c638e2881d29d2"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "74685afb51732a464fbce79a72708f7c4203ceb7"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
-version = "1.2.3"
+version = "1.3.0"
 
 [[deps.SciMLSensitivity]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "ChainRulesCore", "ConstructionBase", "DiffEqBase", "DiffEqCallbacks", "DiffEqNoiseProcess", "Distributions", "Enzyme", "FastBroadcast", "FiniteDiff", "ForwardDiff", "FunctionProperties", "FunctionWrappersWrappers", "Functors", "GPUArraysCore", "LinearAlgebra", "LinearSolve", "Markdown", "OrdinaryDiffEqCore", "PreallocationTools", "QuadGK", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "ReverseDiff", "SciMLBase", "SciMLJacobianOperators", "SciMLLogging", "SciMLStructures", "SparseArrays", "StaticArrays", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tracker", "Zygote"]
@@ -3137,9 +3126,9 @@ version = "7.106.0"
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface", "PrecompileTools"]
-git-tree-sha1 = "14d4ca3d334637233b9f730d2b9e6061e6338122"
+git-tree-sha1 = "5c2f9dbf6f07eea6bc9e93f117b00b7939a79f9e"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.10.3"
+version = "1.10.5"
 
 [[deps.ScientificTypesBase]]
 deps = ["InteractiveUtils"]
@@ -3191,15 +3180,10 @@ uuid = "605ecd9f-84a6-4c9e-81e2-4798472b76a3"
 version = "0.1.0"
 
 [[deps.Showoff]]
-deps = ["Dates", "Grisu"]
-git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
+deps = ["Dates"]
+git-tree-sha1 = "8238217340ad0aaabe11afe39c1098b5bc9f4c8e"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-version = "1.0.3"
-
-[[deps.SimpleBufferStream]]
-git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
-uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
-version = "1.2.0"
+version = "1.1.1"
 
 [[deps.SimpleNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "Setfield", "StaticArraysCore"]
@@ -3236,9 +3220,9 @@ version = "1.11.0"
 
 [[deps.SparseColumnPivotedQR]]
 deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "cd2b583a035b559dbd7c3a9a88c43dc2a86203ca"
+git-tree-sha1 = "8cf1a59c78dd6f900feb366e5a574f99ed278ef1"
 uuid = "a57abbd0-fea5-4d57-96be-5e525945e8e4"
-version = "2.1.4"
+version = "2.1.8"
 weakdeps = ["AMD"]
 
     [deps.SparseColumnPivotedQR.extensions]
@@ -3246,9 +3230,9 @@ weakdeps = ["AMD"]
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "ad4d1275eeb223cbd4d362563954a661fe12d2f7"
+git-tree-sha1 = "5c127b6b5e36e1ba38556b578c6346b2375ec0b4"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "1.2.2"
+version = "1.2.3"
 weakdeps = ["ChainRulesCore", "LogExpFunctions", "NNlib", "NaNMath", "SpecialFunctions"]
 
     [deps.SparseConnectivityTracer.extensions]
@@ -3260,15 +3244,15 @@ weakdeps = ["ChainRulesCore", "LogExpFunctions", "NNlib", "NaNMath", "SpecialFun
 
 [[deps.SparseInverseSubset]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "52962839426b75b3021296f7df242e40ecfc0852"
+git-tree-sha1 = "eec446511ab8c3293dd846c61c15128392fceed5"
 uuid = "dc90abb0-5640-4711-901d-7e5b23a2fada"
-version = "0.1.2"
+version = "0.1.3"
 
 [[deps.SparseMatrixColorings]]
 deps = ["ADTypes", "DocStringExtensions", "LinearAlgebra", "PrecompileTools", "Random", "SparseArrays"]
-git-tree-sha1 = "f63d76c7b7c329cf11badd564fd8ba877b09c3fe"
+git-tree-sha1 = "63e1776f40bbd5e7394edce08e62f852b1384baf"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
-version = "0.4.27"
+version = "0.4.28"
 
     [deps.SparseMatrixColorings.extensions]
     SparseMatrixColoringsCUDAExt = ["CUDA", "cuSPARSE"]
@@ -3288,9 +3272,9 @@ version = "0.4.27"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+git-tree-sha1 = "429071b23f4c9a13fb6582f807cc2ef454082408"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.8.0"
+version = "2.9.0"
 weakdeps = ["ChainRulesCore"]
 
     [deps.SpecialFunctions.extensions]
@@ -3304,9 +3288,9 @@ version = "1.0.4"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "5ef96deaf82834d64e1456c6a6665ca4188afd48"
+git-tree-sha1 = "474a5283ad435618090122872eea6a8165ea6bcf"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.4"
+version = "1.4.6"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
@@ -3321,9 +3305,9 @@ weakdeps = ["OffsetArrays", "StaticArrays"]
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+git-tree-sha1 = "e206cf4850fd7ac4255ffd2b98922f563e18ac53"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.18"
+version = "1.9.20"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -3343,9 +3327,9 @@ version = "3.5.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+git-tree-sha1 = "e2b53ce13a53367e96601081e33d34746b571bad"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.11.1"
+version = "1.11.5"
 weakdeps = ["SparseArrays"]
 
     [deps.Statistics.extensions]
@@ -3359,15 +3343,15 @@ version = "1.8.0"
 
 [[deps.StatsBase]]
 deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+git-tree-sha1 = "adb9da019510162e67a4493fc235c23203d8b09e"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.34.12"
+version = "0.34.13"
 
 [[deps.StatsFuns]]
 deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "91f091a8716a6bb38417a6e6f274602a19aaa685"
+git-tree-sha1 = "0aa97471d55945556e8d2859568b8317cef98351"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "1.5.2"
+version = "1.5.3"
 weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
     [deps.StatsFuns.extensions]
@@ -3393,10 +3377,10 @@ uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 version = "0.5.9"
 
 [[deps.Strided]]
-deps = ["LinearAlgebra", "StridedViews", "TupleTools"]
-git-tree-sha1 = "8c4f33a88bcd7dfee25ef0e59d724781ccd96b35"
+deps = ["LinearAlgebra", "PrecompileTools", "StridedViews", "TupleTools"]
+git-tree-sha1 = "5fa7f6845c91e6e351880cee67a9efc3b892bd3b"
 uuid = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
-version = "2.6.1"
+version = "2.6.4"
 
     [deps.Strided.extensions]
     StridedAMDGPUExt = "AMDGPU"
@@ -3431,9 +3415,9 @@ version = "0.5.2"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "d05693d339e37d6ab134c5ab53c29fce5ee5d7d5"
+git-tree-sha1 = "773065c6e0e903924a9d838259be74338422aef2"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.4"
+version = "0.5.0"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -3456,9 +3440,9 @@ version = "0.3.1"
 
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.8.2"
+version = "2.8.5"
 
     [deps.StructUtils.extensions]
     StructUtilsMeasurementsExt = ["Measurements"]
@@ -3484,10 +3468,10 @@ uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
 version = "7.7.0+0"
 
 [[deps.SymbolicIndexingInterface]]
-deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
-git-tree-sha1 = "73048fd086b7a169bbd7232bf60bfd43240691eb"
+deps = ["Accessors", "ArrayInterface", "PrecompileTools", "RuntimeGeneratedFunctions", "StaticArraysCore"]
+git-tree-sha1 = "7eb6da9656581ac9fbffaef3ef7950a090a5002a"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.51"
+version = "0.3.55"
 weakdeps = ["PrettyTables"]
 
     [deps.SymbolicIndexingInterface.extensions]
@@ -3500,9 +3484,9 @@ version = "1.0.3"
 
 [[deps.TZJData]]
 deps = ["Artifacts"]
-git-tree-sha1 = "72df96b3a595b7aab1e101eb07d2a435963a97e2"
+git-tree-sha1 = "d3b30a9f29a898e21fb4bdf280101b7a12e1f39c"
 uuid = "dc5dba14-91b3-4cab-a142-028a31da12f7"
-version = "1.5.0+2025b"
+version = "1.5.1+2025b"
 
 [[deps.TableOperations]]
 deps = ["SentinelArrays", "Tables", "Test"]
@@ -3518,9 +3502,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
-git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+git-tree-sha1 = "a94d9bdda1b7bed0046cea645639ab3f62196fac"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.13.0"
+version = "1.14.0"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -3541,9 +3525,9 @@ version = "0.1.1"
 
 [[deps.TerminalLoggers]]
 deps = ["LeftChildRightSiblingTrees", "Logging", "Markdown", "Printf", "ProgressLogging", "UUIDs"]
-git-tree-sha1 = "f133fab380933d042f6796eda4e130272ba520ca"
+git-tree-sha1 = "81c9b4137edfe56a56efcdcb35d721b2ce3e2416"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -3580,9 +3564,9 @@ version = "0.5.29"
 
 [[deps.Tracker]]
 deps = ["Adapt", "ChainRulesCore", "DiffRules", "ForwardDiff", "Functors", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NNlib", "NaNMath", "Optimisers", "Printf", "Random", "Requires", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "83697ba2237663355de8fb0a800144cda44848a0"
+git-tree-sha1 = "19b3f57d1b9f9aeff1f905a41818c75e467d07a2"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.38"
+version = "0.2.39"
 weakdeps = ["PDMats"]
 
     [deps.Tracker.extensions]
@@ -3623,23 +3607,19 @@ uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 version = "1.6.0"
 
 [[deps.Turing]]
-deps = ["ADTypes", "AbstractMCMC", "AbstractPPL", "Accessors", "AdvancedHMC", "AdvancedMH", "AdvancedPS", "AdvancedVI", "BangBang", "Bijectors", "Compat", "DataStructures", "Distributions", "DocStringExtensions", "DynamicPPL", "EllipticalSliceSampling", "FlexiChains", "ForwardDiff", "Libtask", "LinearAlgebra", "LogDensityProblems", "Optimization", "OptimizationOptimJL", "OrderedCollections", "Printf", "Random", "Reexport", "SciMLBase", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "36243b86c346ac2329f931b31d00c0f147f77381"
+deps = ["ADTypes", "AbstractMCMC", "AbstractPPL", "Accessors", "AdvancedHMC", "AdvancedMH", "AdvancedVI", "BangBang", "Bijectors", "Compat", "DataStructures", "Distributions", "DocStringExtensions", "DynamicPPL", "EllipticalSliceSampling", "FlexiChains", "ForwardDiff", "Libtask", "LinearAlgebra", "LogDensityProblems", "Optimization", "OptimizationOptimJL", "OrderedCollections", "Printf", "Random", "Random123", "Reexport", "SciMLBase", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "6ae6ea2c2c83718587ba504f78235e460cce9551"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.46.0"
+version = "0.48.0"
 
     [deps.Turing.extensions]
+    TuringDistributionsExt = "Distributions"
     TuringDynamicHMCExt = "DynamicHMC"
     TuringMCMCChainsExt = "MCMCChains"
 
     [deps.Turing.weakdeps]
     DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb"
     MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-
-[[deps.URIs]]
-git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.6.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -3657,9 +3637,9 @@ uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 version = "0.4.1"
 
 [[deps.UnsafeAtomics]]
-git-tree-sha1 = "0f30765c32d66d58e41f4cb5624d4fc8a82ec13b"
+git-tree-sha1 = "21b39bfb1fab6156b61fbcba4c86c57b6216d2c3"
 uuid = "013be700-e6cd-48c3-b4a1-df204f14c38f"
-version = "0.3.1"
+version = "0.3.2"
 weakdeps = ["LLVM"]
 
     [deps.UnsafeAtomics.extensions]
@@ -3710,9 +3690,9 @@ version = "1.3.4"
 
 [[deps.Widgets]]
 deps = ["Colors", "Dates", "Observables", "OrderedCollections"]
-git-tree-sha1 = "e9aeb174f95385de31e70bd15fa066a505ea82b9"
+git-tree-sha1 = "cab29ed70d9355a28b95b1798007ff3a00eefc91"
 uuid = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
-version = "0.6.7"
+version = "0.6.8"
 
 [[deps.WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -3781,9 +3761,9 @@ version = "6.0.2+0"
 
 [[deps.Xorg_libXi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
-git-tree-sha1 = "a376af5c7ae60d29825164db40787f15c80c7c54"
+git-tree-sha1 = "dcb316b3ce0941f195537dda56bea4517fcd3ff5"
 uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
-version = "1.8.3+0"
+version = "1.8.4+0"
 
 [[deps.Xorg_libXinerama_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll"]
@@ -3888,9 +3868,9 @@ version = "1.5.7+1"
 
 [[deps.Zygote]]
 deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "GPUArraysCore", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "PrecompileTools", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "615fae83fbb607abc43cf2f84f51bcf3be1a706b"
+git-tree-sha1 = "a1ec45a8a0adee4d581a37f7e1a0fb401c1cb113"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.7.11"
+version = "0.7.13"
 
     [deps.Zygote.extensions]
     ZygoteAtomExt = "Atom"
@@ -3908,9 +3888,9 @@ version = "0.7.11"
 
 [[deps.ZygoteRules]]
 deps = ["ChainRulesCore", "MacroTools"]
-git-tree-sha1 = "434b3de333c75fc446aa0d19fc394edafd07ab08"
+git-tree-sha1 = "c6a86c133861234450ab260dee01b42abd604095"
 uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.2.7"
+version = "0.2.8"
 
 [[deps.eudev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -3926,15 +3906,15 @@ version = "0.61.1+0"
 
 [[deps.libaom_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "850b06095ee71f0135d644ffd8a52850699581ed"
+git-tree-sha1 = "ef17c47d22224aaecc76e597ab21a072e025cf7b"
 uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
-version = "3.13.3+0"
+version = "3.14.1+0"
 
 [[deps.libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
+git-tree-sha1 = "cb007192783c56d8249db4cf0e3495001edfe414"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.17.4+0"
+version = "0.17.5+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -3949,9 +3929,9 @@ version = "0.2.2+0"
 
 [[deps.libdrm_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]
-git-tree-sha1 = "63aac0bcb0b582e11bad965cef4a689905456c03"
+git-tree-sha1 = "28e57478e8a160d346a19c28b3fffb9273bcc9c2"
 uuid = "8e53e030-5e6c-5a89-a30b-be5b7263a166"
-version = "2.4.125+1"
+version = "2.4.134+0"
 
 [[deps.libevdev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -53,4 +53,4 @@ StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
-Turing = "0.46"
+Turing = "0.48"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,7 +43,7 @@ website:
         href: https://turinglang.org/team/
     right:
       # Current version
-      - text: "v0.46"
+      - text: "v0.48"
         menu:
           - text: Changelog
             href: https://turinglang.org/docs/changelog.html

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -125,13 +125,14 @@ The arguments for each sampler are:
 - SMC: resampling scheme (optional). The number of samples requested from `sample` is the number of particles in the single sweep.
 - PG: number of particles, resampling scheme (optional).
 - HMC: leapfrog step size, leapfrog step numbers.
+- MH: no arguments to propose from the prior, or a covariance matrix for a Gaussian random walk over the complete linked parameter vector, as in `MH(0.1 * I(2))`.
 - Gibbs: pairs of variable names and the component sampler for each.
 - NUTS: number of adaptation steps (optional), target accept ratio.
 
 More information about each sampler can be found in [Turing.jl's API docs](https://turinglang.org/Turing.jl).
 
 FlexiChains.jl provides plotting tools for the `VNChain` objects returned by a `sample` function.
-For more information about FlexiChains and its plotting capabilities, please see the [FlexiChains.jl documentation](https://pysm.dev/FlexiChains.jl/stable).
+For more information about FlexiChains and its plotting capabilities, please see the [FlexiChains.jl documentation](https://juliabayes.org/FlexiChains.jl/stable/).
 
 ```julia
 using FlexiChains
@@ -189,7 +190,7 @@ var_1 = mean(chn[@varname(var_1)]) # Taking the mean of a variable named var_1.
 
 The key should be a `VarName`, constructed with the `@varname` macro.
 
-FlexiChains has a very powerful indexing interface, which includes the ability to index into sub-variables: please see [the FlexiChains docs](https://pysm.dev/FlexiChains.jl/stable/turing/#Accessing-data) for more information.
+FlexiChains has a very powerful indexing interface, which includes the ability to index into sub-variables: please see [the FlexiChains docs](https://juliabayes.org/FlexiChains.jl/stable/turing#Accessing-data) for more information.
 
 ### Tilde-statement ordering
 
@@ -396,17 +397,14 @@ chain = sample(m, HMC(0.01, 5), 1000)
 
 #### Access Values inside Chain
 
-You can access the values inside a chain in several ways:
+`sample` returns a `FlexiChains.VNChain`, and its values are reached by indexing with a `VarName`.
+For a chain `c`:
 
- 1. Turn them into a `DataFrame` object
- 2. Use their raw `AxisArray` form
- 3. Create a three-dimensional `Array` object
+ 1. `c[@varname(x)]` returns the draws of `x` as a matrix with one row per iteration and one column per chain, and `c[@varname(x), iter=1, chain=1]` picks out a single draw.
+ 2. `c[@varname(x[1])]` indexes into an array-valued variable, and `c[[@varname(x[1]), @varname(x[2])]]` keeps only the listed keys.
+ 3. `DataFrame(c)` converts the chain to a `DataFrame` through the Tables.jl interface (after `using DataFrames`), and `MCMCChains.Chains(c)` converts it to an `MCMCChains.Chains` if you need the older format.
 
-For example, let `c` be a `Chain`:
-
- 1. `DataFrame(c)` converts `c` to a `DataFrame`,
- 2. `c.value` retrieves the values inside `c` as an `AxisArray`, and
- 3. `c.value.data` retrieves the values inside `c` as a 3D `Array`.
+The [FlexiChains indexing documentation](https://juliabayes.org/FlexiChains.jl/stable/indexing) describes the selectors in full.
 
 #### Variable Types and Type Parameters
 
@@ -549,6 +547,45 @@ Please see the [Automatic Differentiation]({{<meta usage-automatic-differentiati
 
 For more details of compositional sampling in Turing.jl, please see [the corresponding paper](https://proceedings.mlr.press/v84/ge18b.html).
 
+A Gibbs chain also carries the statistics that its component samplers report, prefixed with the variable each component samples.
+For the sampler above, the HMC component's statistics appear as `p_acceptance_rate`, `p_step_size` and so on, so `chn[FlexiChains.Extra(:p_acceptance_rate)]` retrieves one of them after `using FlexiChains`.
+
+### Particle samplers: SMC and PG
+
+`SMC` runs a single sequential Monte Carlo sweep, and the number of samples you ask `sample` for is the number of particles in that sweep.
+The particles are resampled once at the end, so the returned draws carry equal weight and can be summarised directly.
+
+```{julia}
+using FlexiChains
+c_smc = sample(gdemo(1.5, 2), SMC(), 1000)
+```
+
+Every draw of an `SMC` chain carries the same `log_normalizing_constant`, whose exponential is an unbiased estimate of the marginal likelihood of the data under the usual particle-filter assumptions, and an `ess_per_step` vector with the effective sample size after each likelihood term.
+
+```{julia}
+c_smc[FlexiChains.Extra(:log_normalizing_constant)][1], c_smc[FlexiChains.Extra(:ess_per_step)][1]
+```
+
+By default both samplers resample with the stratified scheme whenever the effective sample size drops below half the number of particles.
+The scheme and the threshold can be chosen: the scheme types are `StratifiedResampler`, `SystematicResampler` and `MultinomialResampler`, all in `Turing.Inference`, and the threshold is a fraction of the particle count.
+
+```{julia}
+c_sys = sample(gdemo(1.5, 2), SMC(Turing.Inference.SystematicResampler(), 0.5), 1000)
+c_pg = sample(gdemo(1.5, 2), PG(10, Turing.Inference.MultinomialResampler(), 0.5), 200)
+```
+
+`PG` chains also carry `log_normalizing_constant`, but for `PG` its exponential is a biased estimate of the marginal likelihood and must not be used for model comparison, as explained in the `PG` docstring.
+
+Passing `multithreaded=true` to either constructor spreads the particles of each sweep across threads without changing the results.
+This is independent of `MCMCThreads()`, which parallelises whole chains, and needs Julia to be started with several threads to have any effect.
+
+```julia
+sample(gdemo(1.5, 2), SMC(; multithreaded=true), 1000)
+sample(gdemo(1.5, 2), PG(10; multithreaded=true), 200)
+```
+
+Because `SMC` performs one sweep rather than an MCMC loop, it has no sampler state to save or resume, so `save_state` and `initial_state` have no effect on it.
+
 ### Working with `filldist` and `arraydist`
 
 Turing.jl provides convenience wrappers `filldist(dist::Distribution, n::Int)` and `arraydist(dists::AbstractVector{<:Distribution})` to construct product distributions, e.g., to model a set of variables that share the same structure but vary by group.
@@ -601,7 +638,7 @@ For more information on Turing's automatic differentiation backend, please see t
 
 `Turing.jl` uses ProgressLogging.jl to log the sampling progress.
 Progress logging is enabled as default but might slow down inference.
-It can be turned on or off by setting the keyword argument `progress` of `sample`; see the [Sampling Options]{{<meta usage-sampling-options>}} page for more details.
+It can be turned on or off by setting the keyword argument `progress` of `sample`; see the [Sampling Options]({{<meta usage-sampling-options>}}) page for more details.
 Moreover, you can enable or disable progress logging globally by calling `setprogress!(true)` or `setprogress!(false)`, respectively.
 
 Turing uses heuristics to select an appropriate visualisation backend.

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -535,9 +535,11 @@ chn = sample(simple_choice_f, Gibbs(:p => HMC(0.2, 3), :z => PG(20)), 1000)
 ```
 
 Every variable the model reaches must belong to a component, and several variables can share one component by passing them together, as in `Gibbs((:p, :z) => PG(20))`.
-A component may not change the dimension of a variable that belongs to another component, or whether that variable exists at all.
+A value the model stores as a unit cannot be split between components: `x[1] ~ Normal()` and `x[2] ~ Normal()` can go to different components, but `x ~ MvNormal(...)` must go to one.
+A component may not change the dimension of a variable that belongs only to another component, or whether that variable exists at all.
 If one variable decides the shape of another, for example a count that sets the length of a vector, put both in the same component.
-Gibbs stops with an error when it detects such a change, and the `Gibbs` docstring explains which partitions are safe.
+Gibbs stops with an error when it detects such a change, but the check only sees states a component accepted, so a run that completes is not proof that the partition is valid.
+The `Gibbs` docstring explains which partitions are safe.
 
 Gibbs does not support model arguments that contain `missing`.
 Declare the latent variable inside the model and condition on the observations with `|` or `condition` instead.

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -568,6 +568,8 @@ c_smc[FlexiChains.Extra(:log_normalizing_constant)][1], c_smc[FlexiChains.Extra(
 
 By default both samplers resample with the stratified scheme whenever the effective sample size drops below half the number of particles.
 The scheme and the threshold can be chosen: the scheme types are `StratifiedResampler`, `SystematicResampler` and `MultinomialResampler`, all in `Turing.Inference`, and the threshold is a fraction of the particle count.
+For `PG` the chosen scheme is used in the first, unconditional sweep only.
+The later conditional sweeps keep the threshold but always draw their ancestors from the multinomial distribution over the weights, whatever scheme was chosen.
 
 ```{julia}
 c_sys = sample(gdemo(1.5, 2), SMC(Turing.Inference.SystematicResampler(), 0.5), 1000)

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -122,10 +122,10 @@ c5 = sample(gdemo(1.5, 2), NUTS(0.65), 1000)
 
 The arguments for each sampler are:
 
-- SMC: number of particles.
-- PG: number of particles, number of iterations.
+- SMC: resampling scheme (optional). The number of samples requested from `sample` is the number of particles in the single sweep.
+- PG: number of particles, resampling scheme (optional).
 - HMC: leapfrog step size, leapfrog step numbers.
-- Gibbs: component sampler 1, component sampler 2, ...
+- Gibbs: pairs of variable names and the component sampler for each.
 - NUTS: number of adaptation steps (optional), target accept ratio.
 
 More information about each sampler can be found in [Turing.jl's API docs](https://turinglang.org/Turing.jl).
@@ -535,6 +535,14 @@ simple_choice_f = simple_choice([1.5, 2.0, 0.3])
 
 chn = sample(simple_choice_f, Gibbs(:p => HMC(0.2, 3), :z => PG(20)), 1000)
 ```
+
+Every variable the model reaches must belong to a component, and several variables can share one component by passing them together, as in `Gibbs((:p, :z) => PG(20))`.
+A component may not change the dimension of a variable that belongs to another component, or whether that variable exists at all.
+If one variable decides the shape of another, for example a count that sets the length of a vector, put both in the same component.
+Gibbs stops with an error when it detects such a change, and the `Gibbs` docstring explains which partitions are safe.
+
+Gibbs does not support model arguments that contain `missing`.
+Declare the latent variable inside the model and condition on the observations with `|` or `condition` instead.
 
 The `Gibbs` sampler can be used to specify unique automatic differentiation backends for different variable spaces.
 Please see the [Automatic Differentiation]({{<meta usage-automatic-differentiation>}}) page for more.

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -125,7 +125,7 @@ The arguments for each sampler are:
 - SMC: resampling scheme (optional). The number of samples requested from `sample` is the number of particles in the single sweep.
 - PG: number of particles, resampling scheme (optional).
 - HMC: leapfrog step size, leapfrog step numbers.
-- MH: no arguments to propose from the prior, or a covariance matrix for a Gaussian random walk over the complete linked parameter vector, as in `MH(0.1 * I(2))`.
+- MH: propose from the prior if `MH()`, or from a Gaussian random walk if `MH(cov)` over the unconstrained parameter vector, as in `MH(0.1 * I(2))`.
 - Gibbs: pairs of variable names and the component sampler for each.
 - NUTS: number of adaptation steps (optional), target accept ratio.
 

--- a/core-functionality/index.qmd
+++ b/core-functionality/index.qmd
@@ -588,7 +588,8 @@ sample(gdemo(1.5, 2), SMC(; multithreaded=true), 1000)
 sample(gdemo(1.5, 2), PG(10; multithreaded=true), 200)
 ```
 
-Because `SMC` performs one sweep rather than an MCMC loop, it has no sampler state to save or resume, so `save_state` and `initial_state` have no effect on it.
+Because `SMC` performs one sweep rather than an MCMC loop, it has no iterations to discard, thin or call back from and no sampler state to save or resume.
+It ignores `discard_initial`, `thinning`, `callback`, `save_state`, `initial_state` and `initial_params`, and warns when any of them is passed.
 
 ### Working with `filldist` and `arraydist`
 

--- a/developers/inference/abstractmcmc-interface/index.qmd
+++ b/developers/inference/abstractmcmc-interface/index.qmd
@@ -122,8 +122,8 @@ Metropolis-Hastings proposes ``\theta' \sim q(\theta' \mid \theta)`` and accepts
 
 A symmetric random-walk proposal has ``q(\theta \mid \theta') = q(\theta' \mid \theta)``, so the ratio of proposal densities cancels and the log acceptance probability is ``\min[0, \log \pi(\theta') - \log \pi(\theta)]``.
 
-The first `step` chooses the starting point.
-`sample` passes its `initial_params` keyword argument through to this method, so the sampler honours it and otherwise draws a start from the proposal distribution.
+Supply a starting point with finite log density through `initial_params`.
+`sample` passes that keyword argument through to the first `step`, which refuses to start without it or outside the support, because the acceptance test below cannot move a chain whose current log density is `-Inf`.
 
 ```{julia}
 function AbstractMCMC.step(
@@ -133,8 +133,10 @@ function AbstractMCMC.step(
     initial_params=nothing,
     kwargs...,
 )
-    θ = initial_params === nothing ? rand(rng, sampler.proposal) : initial_params
+    initial_params === nothing && throw(ArgumentError("initial_params is required"))
+    θ = initial_params
     lp = LogDensityProblems.logdensity(model.logdensity, θ)
+    isfinite(lp) || throw(ArgumentError("initial_params must have finite log density"))
     return θ, MHState(θ, lp)
 end
 ```

--- a/developers/inference/abstractmcmc-interface/index.qmd
+++ b/developers/inference/abstractmcmc-interface/index.qmd
@@ -163,7 +163,8 @@ end
 ### Sampling
 
 That is the whole sampler.
-`sample` runs the two methods, discards the first 2000 draws, and returns the remaining transitions as a vector.
+`sample` runs the two methods, throws away the first 2000 draws, and then collects the 20000 requested transitions and returns them as a vector.
+`discard_initial` adds steps in front of the requested number, it does not take them out of it.
 
 ```{julia}
 sampler = MetropolisHastings(MvNormal(zeros(2), 0.25 * I))

--- a/developers/inference/abstractmcmc-interface/index.qmd
+++ b/developers/inference/abstractmcmc-interface/index.qmd
@@ -1,6 +1,8 @@
 ---
 title: Interface Guide
 engine: julia
+julia:
+    exeflags: ["--project=@.", "-t 4"]
 aliases:
   - ../../tutorials/docs-06-for-developers-interface/index.html
 ---
@@ -14,310 +16,195 @@ Pkg.instantiate();
 
 # The sampling interface
 
-Turing implements a sampling interface (hosted at [AbstractMCMC](https://github.com/TuringLang/AbstractMCMC.jl)) that is intended to provide a common framework for Markov chain Monte Carlo samplers. The interface presents several structures and functions that one needs to overload in order to implement an interface-compatible sampler.
+Turing's samplers are built on the interface defined in [AbstractMCMC.jl](https://github.com/TuringLang/AbstractMCMC.jl), a small set of types and functions that any Markov chain Monte Carlo sampler can implement.
+A sampler written against this interface gets multiple-chain sampling, warmup and thinning, progress logging and callbacks from `sample` without writing any of that itself, and can be used on Turing models through `externalsampler`.
 
-This guide will demonstrate how to implement the interface without Turing.
+This guide implements the interface without Turing, using a Metropolis-Hastings sampler as the example.
+The [Implementing Samplers]({{< meta using-turing-implementing-samplers >}}) page works through a second, more involved example, and the [External Samplers]({{< meta usage-external-samplers >}}) page lists what Turing additionally needs from a sampler.
 
 ## Interface overview
 
-Any implementation of an inference method that uses the AbstractMCMC interface should implement a subset of the following types and functions:
+A sampler implements:
 
-1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information or sampler parameters.
-2. A function `sample_init!` which performs any necessary set-up (default: do not perform any set-up).
-3. A function `step!` which returns a transition that represents a single draw from the sampler.
-4. A function `transitions_init` which returns a container for the transitions obtained from the sampler (default: return a `Vector{T}` of length `N` where `T` is the type of the transition obtained in the first step and `N` is the number of requested samples).
-5. A function `transitions_save!` which saves transitions to the container (default: save the transition of iteration `i` at position `i` in the vector of transitions).
-6. A function `sample_end!` which handles any sampler wrap-up (default: do not perform any wrap-up).
-7. A function `bundle_samples` which accepts the container of transitions and returns a collection of samples (default: return the vector of transitions).
+1. A subtype of `AbstractMCMC.AbstractSampler`.
+   The sampler struct holds settings only.
+   Anything that changes between iterations belongs in the state, not in the sampler.
+2. Two methods of `AbstractMCMC.step`.
+   The first, `step(rng, model, sampler; kwargs...)`, produces the initial draw.
+   The second, `step(rng, model, sampler, state; kwargs...)`, produces the next draw from the current state.
+   Both return a tuple `(transition, state)`: the transition is what the user sees in the output, and the state carries whatever the next step needs.
 
-The interface methods with exclamation points are those that are intended to allow for state mutation. Any mutating function is meant to allow mutation where needed -- you might use:
+Optionally, it can also implement:
 
-- `sample_init!` to run some kind of sampler preparation, before sampling begins. This could mutate a sampler's state.
-- `step!` might mutate a sampler flag after each sample.
-- `sample_end!` contains any wrap-up you might need to do. If you were sampling in a transformed space, this might be where you convert everything back to a constrained space.
+- `AbstractMCMC.getparams(state)` and `AbstractMCMC.getstats(state)`, which Turing's `externalsampler` uses to read parameters and statistics from the state.
+- `AbstractMCMC.bundle_samples(samples, model, sampler, state, chain_type; kwargs...)`, to convert the vector of transitions into a chain format of your choice when `sample` is called with that `chain_type`.
+
+Everything else comes from `sample`: `MCMCThreads()`, `MCMCDistributed()` and `MCMCSerial()` for several chains, `num_warmup`, `discard_initial` and `thinning`, progress logging, `callback`, and `initial_params` and `initial_state` for choosing where to start.
 
 ## Why do you have an interface?
 
-The motivation for the interface is to allow Julia's fantastic probabilistic programming language community to have a set of standards and common implementations so we can all thrive together. Markov chain Monte Carlo methods tend to have a very similar framework to one another, and so a common interface should help more great inference methods built in single-purpose packages to experience more use among the community.
+Markov chain Monte Carlo methods share most of their machinery: run a kernel repeatedly, keep the draws, report progress, run several chains at once.
+An interface lets each sampler package implement only its kernel and share the rest, and lets one sampler serve every model implementation that speaks the interface, Turing models included.
 
 ## Implementing Metropolis-Hastings without Turing
 
-[Metropolis-Hastings](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) is often the first sampling method that people are exposed to. It is a very straightforward algorithm and is accordingly the easiest to implement, so it makes for a good example. In this section, you will learn how to use the types and functions listed above to implement the Metropolis-Hastings sampler using the MCMC interface.
-
-The full code for this implementation is housed in [AdvancedMH.jl](https://github.com/TuringLang/AdvancedMH.jl).
+[Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm) is often the first sampling method that people meet, and it is short enough to implement completely here.
+A full implementation with several proposal types lives in [AdvancedMH.jl](https://github.com/TuringLang/AdvancedMH.jl).
 
 ### Imports
 
-Let's begin by importing the relevant libraries. We'll import `AbstractMCMC`, which contains the interface framework we'll fill out. We also need `Distributions` and `Random`.
-
 ```{julia}
-# Import the relevant libraries.
 using AbstractMCMC: AbstractMCMC
 using Distributions
+using LinearAlgebra: I
+using LogDensityProblems
 using Random
+using Statistics: mean, std
 ```
-
-An interface extension (like the one we're writing right now) typically requires that you overload or implement several functions. Specifically, you should `import` the functions you intend to overload. This next code block accomplishes that.
-
-From `Distributions`, we need `Sampleable`, `VariateForm`, and `ValueSupport`, three abstract types that define a distribution. Models in the interface are assumed to be subtypes of `Sampleable{VariateForm, ValueSupport}`. In this section our model is going to be extremely simple, so we will not end up using these except to make sure that the inference functions are dispatching correctly.
-
-### Sampler
-
-Let's begin our sampler definition by defining a sampler called `MetropolisHastings` which is a subtype of `AbstractSampler`. Correct typing is very important for proper interface implementation -- if you are missing a subtype, your method may not be dispatched to when you call `sample`.
-
-```{julia}
-# Define a sampler type.
-struct MetropolisHastings{T,D} <: AbstractMCMC.AbstractSampler
-    init_θ::T
-    proposal::D
-end
-
-# Default constructors.
-MetropolisHastings(init_θ::Real) = MetropolisHastings(init_θ, Normal(0, 1))
-function MetropolisHastings(init_θ::Vector{<:Real})
-    return MetropolisHastings(init_θ, MvNormal(zero(init_θ), I))
-end
-```
-
-Above, we have defined a sampler that stores the initial parameterisation of the prior, and a distribution object from which proposals are drawn. You can have a struct that has no fields, and simply use it for dispatching onto the relevant functions, or you can store a large amount of state information in your sampler.
-
-The general intuition for what to store in your sampler struct is that anything you may need to perform inference between samples but you don't want to store in a transition should go into the sampler struct. It's the only way you can carry non-sample related state information between `step!` calls.
 
 ### Model
 
-Next, we need to have a model of some kind. A model is a struct that's a subtype of `AbstractModel` that contains whatever information is necessary to perform inference on your problem. In our case we want to know the mean and variance parameters for a standard Normal distribution, so we can keep our model to the log density of a Normal.
+The sampler needs one thing from the model: the log density at a parameter vector.
+AbstractMCMC wraps any object that implements the [LogDensityProblems.jl](https://github.com/tpapp/LogDensityProblems.jl) interface in `AbstractMCMC.LogDensityModel`, and samplers define their `step` methods on that wrapper.
+Turing models are turned into such objects for you, so a sampler written this way runs on them unchanged.
 
-Note that we only have to do this because we are not yet integrating the sampler with Turing -- Turing has a very sophisticated modelling engine that removes the need to define custom model structs.
+For this guide the target is the posterior of the mean and standard deviation of a Normal distribution given 30 observations, with a flat prior.
 
 ```{julia}
-# Define a model type. Stores the log density function.
-struct DensityModel{F<:Function} <: AbstractMCMC.AbstractModel
-    ℓπ::F
+struct NormalDensity{T}
+    data::T
+end
+
+function LogDensityProblems.logdensity(d::NormalDensity, θ)
+    μ, σ = θ
+    return σ > 0 ? sum(logpdf.(Normal(μ, σ), d.data)) : -Inf
+end
+LogDensityProblems.dimension(::NormalDensity) = 2
+function LogDensityProblems.capabilities(::Type{<:NormalDensity})
+    return LogDensityProblems.LogDensityOrder{0}()
+end
+
+data = rand(Xoshiro(1), Normal(5, 3), 30)
+model = AbstractMCMC.LogDensityModel(NormalDensity(data))
+```
+
+### Sampler
+
+The sampler holds the proposal distribution and nothing else.
+
+```{julia}
+struct MetropolisHastings{D} <: AbstractMCMC.AbstractSampler
+    proposal::D
 end
 ```
 
-### Transition
+### State
 
-The next step is to define some transition which we will return from each `step!` call. We'll keep it simple by just defining a wrapper struct that contains the parameter draws and the log density of that draw:
+The state holds the current position and its log density.
+Caching the log density means each iteration evaluates the model once, for the proposal, rather than twice.
 
 ```{julia}
-# Create a very basic Transition type, only stores the 
-# parameter draws and the log probability of the draw.
-struct Transition{T,L}
+struct MHState{T,L}
     θ::T
     lp::L
 end
-
-# Store the new draw and its log density.
-Transition(model::DensityModel, θ) = Transition(θ, ℓπ(model, θ))
 ```
 
-`Transition` can now store any type of parameter, whether it's a vector of draws from multiple parameters or a single univariate draw.
-
-### Metropolis-Hastings
-
-Now it's time to get into the actual inference. We've defined all of the core pieces we need, but we need to implement the `step!` function which actually performs inference.
-
-As a refresher, Metropolis-Hastings implements a very basic algorithm:
-
-1. Pick some initial state, ``\theta_0``.
-
-2. For ``t`` in ``[1,N],`` do
-    
-    + Generate a proposal parameterisation ``\theta^\prime_t \sim q(\theta^\prime_t \mid \theta_{t-1}).``
-
-    + Calculate the acceptance probability, ``\alpha = \text{min}\left[1,\frac{\pi(\theta'_t)}{\pi(\theta_{t-1})} \frac{q(\theta_{t-1} \mid \theta'_t)}{q(\theta'_t \mid \theta_{t-1})}) \right].``
-
-    + If ``U \le \alpha`` where ``U \sim [0,1],`` then ``\theta_t = \theta'_t.`` Otherwise, ``\theta_t = \theta_{t-1}.``
-
-Of course, it's much easier to do this in the log space, so the acceptance probability is more commonly written as
-
-```{.cell-bg}
-\log \alpha = \min\left[0, \log \pi(\theta'_t) - \log \pi(\theta_{t-1}) + \log q(\theta_{t-1} \mid \theta^\prime_t) - \log q(\theta\prime_t \mid \theta_{t-1}) \right].
-```
-
-In interface terms, we should do the following:
-
-1. Make a new transition containing a proposed sample.
-2. Calculate the acceptance probability.
-3. If we accept, return the new transition, otherwise, return the old one.
+The transition, the value returned to the user, is the parameter vector itself.
 
 ### Steps
 
-The `step!` function is the function that performs the bulk of your inference. In our case, we will implement two `step!` functions -- one for the very first iteration, and one for every subsequent iteration.
-
-```{julia}
-#| eval: false
-# Define the first step! function, which is called at the 
-# beginning of sampling. Return the initial parameter used
-# to define the sampler.
-function AbstractMCMC.step!(
-    rng::AbstractRNG,
-    model::DensityModel,
-    spl::MetropolisHastings,
-    N::Integer,
-    ::Nothing;
-    kwargs...,
-)
-    return Transition(model, spl.init_θ)
-end
-```
-
-The first `step!` function just packages up the initial parameterisation inside the sampler, and returns it. We implicitly accept the very first parameterisation.
-
-The other `step!` function performs the usual steps from Metropolis-Hastings. Included are several helper functions, `proposal` and `q`, which are designed to replicate the functions in the pseudocode above.
-
-- `proposal` generates a new proposal in the form of a `Transition`, which can be univariate if the value passed in is univariate, or it can be multivariate if the `Transition` given is multivariate. Proposals use a basic `Normal` or `MvNormal` proposal distribution.
-- `q` returns the log density of one parameterisation conditional on another, according to the proposal distribution.
-- `step!` generates a new proposal, checks the acceptance probability, and then returns either the previous transition or the proposed transition.
-
-
-```{julia}
-#| eval: false
-# Define a function that makes a basic proposal depending on a univariate
-# parameterisation or a multivariate parameterisation.
-function propose(spl::MetropolisHastings, model::DensityModel, θ::Real)
-    return Transition(model, θ + rand(spl.proposal))
-end
-function propose(spl::MetropolisHastings, model::DensityModel, θ::Vector{<:Real})
-    return Transition(model, θ + rand(spl.proposal))
-end
-function propose(spl::MetropolisHastings, model::DensityModel, t::Transition)
-    return propose(spl, model, t.θ)
-end
-
-# Calculates the probability `q(θ|θcond)`, using the proposal distribution `spl.proposal`.
-q(spl::MetropolisHastings, θ::Real, θcond::Real) = logpdf(spl.proposal, θ - θcond)
-function q(spl::MetropolisHastings, θ::Vector{<:Real}, θcond::Vector{<:Real})
-    return logpdf(spl.proposal, θ - θcond)
-end
-q(spl::MetropolisHastings, t1::Transition, t2::Transition) = q(spl, t1.θ, t2.θ)
-
-# Calculate the density of the model given some parameterisation.
-ℓπ(model::DensityModel, θ) = model.ℓπ(θ)
-ℓπ(model::DensityModel, t::Transition) = t.lp
-
-# Define the other step function. Returns a Transition containing
-# either a new proposal (if accepted) or the previous proposal 
-# (if not accepted).
-function AbstractMCMC.step!(
-    rng::AbstractRNG,
-    model::DensityModel,
-    spl::MetropolisHastings,
-    ::Integer,
-    θ_prev::Transition;
-    kwargs...,
-)
-    # Generate a new proposal.
-    θ = propose(spl, model, θ_prev)
-
-    # Calculate the log acceptance probability.
-    α = ℓπ(model, θ) - ℓπ(model, θ_prev) + q(spl, θ_prev, θ) - q(spl, θ, θ_prev)
-
-    # Decide whether to return the previous θ or the new one.
-    if log(rand(rng)) < min(α, 0.0)
-        return θ
-    else
-        return θ_prev
-    end
-end
-```
-
-### Chains
-
-In the default implementation, `sample` just returns a vector of all transitions. If instead you would like to obtain a `Chains` object (e.g., to simplify downstream analysis), you have to implement the `bundle_samples` function as well. It accepts the vector of transitions and returns a collection of samples. Fortunately, our `Transition` is incredibly simple, and we only need to build a little bit of functionality to accept custom parameter names passed in by the user.
-
-```{julia}
-#| eval: false
-# A basic chains constructor that works with the Transition struct we defined.
-function AbstractMCMC.bundle_samples(
-    rng::AbstractRNG,
-    ℓ::DensityModel,
-    s::MetropolisHastings,
-    N::Integer,
-    ts::Vector{<:Transition},
-    chain_type::Type{Any};
-    param_names=missing,
-    kwargs...,
-)
-    # Turn all the transitions into a vector-of-vectors.
-    vals = copy(reduce(hcat, [vcat(t.θ, t.lp) for t in ts])')
-
-    # Check if we received any parameter names.
-    if ismissing(param_names)
-        param_names = ["Parameter $i" for i in 1:(length(first(vals)) - 1)]
-    end
-
-    # Add the log density field to the parameter names.
-    push!(param_names, "lp")
-
-    # Bundle everything up and return a Chains struct.
-    return Chains(vals, param_names, (internals=["lp"],))
-end
-```
-
-All done!
-
-You can even implement different output formats by implementing `bundle_samples` for different `chain_type`s, which can be provided as keyword argument to `sample`. As default `sample` uses `chain_type = Any`.
-
-### Testing the implementation
-
-Now that we have all the pieces, we should test the implementation by defining a model to calculate the mean and variance parameters of a Normal distribution. We can do this by constructing a target density function, providing a sample of data, and then running the sampler with `sample`.
-
-```{julia}
-#| eval: false
-# Generate a set of data from the posterior we want to estimate.
-data = rand(Normal(5, 3), 30)
-
-# Define the components of a basic model.
-insupport(θ) = θ[2] >= 0
-dist(θ) = Normal(θ[1], θ[2])
-density(θ) = insupport(θ) ? sum(logpdf.(dist(θ), data)) : -Inf
-
-# Construct a DensityModel.
-model = DensityModel(density)
-
-# Set up our sampler with initial parameters.
-spl = MetropolisHastings([0.0, 0.0])
-
-# Sample from the posterior.
-chain = sample(model, spl, 100000; param_names=["μ", "σ"])
-```
-
-If all the interface functions have been extended properly, you should get an output from `display(chain)` that looks something like this:
-
+Metropolis-Hastings proposes ``\theta' \sim q(\theta' \mid \theta)`` and accepts it with probability
 
 ```{.cell-bg}
-Object of type Chains, with data of type 100000×3×1 Array{Float64,3}
-
-Iterations        = 1:100000
-Thinning interval = 1
-Chains            = 1
-Samples per chain = 100000
-internals         = lp
-parameters        = μ, σ
-
-2-element Array{ChainDataFrame,1}
-
-Summary Statistics
-
-│ Row │ parameters │ mean    │ std      │ naive_se   │ mcse       │ ess     │ r_hat   │
-│     │ Symbol     │ Float64 │ Float64  │ Float64    │ Float64    │ Any     │ Any     │
-├─────┼────────────┼─────────┼──────────┼────────────┼────────────┼─────────┼─────────┤
-│ 1   │ μ          │ 5.33157 │ 0.854193 │ 0.0027012  │ 0.00893069 │ 8344.75 │ 1.00009 │
-│ 2   │ σ          │ 4.54992 │ 0.632916 │ 0.00200146 │ 0.00534942 │ 14260.8 │ 1.00005 │
-
-Quantiles
-
-│ Row │ parameters │ 2.5%    │ 25.0%   │ 50.0%   │ 75.0%   │ 97.5%   │
-│     │ Symbol     │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │
-├─────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-│ 1   │ μ          │ 3.6595  │ 4.77754 │ 5.33182 │ 5.89509 │ 6.99651 │
-│ 2   │ σ          │ 3.5097  │ 4.09732 │ 4.47805 │ 4.93094 │ 5.96821 │
+\alpha = \min\left[1, \frac{\pi(\theta')}{\pi(\theta)} \frac{q(\theta \mid \theta')}{q(\theta' \mid \theta)}\right].
 ```
 
-It looks like we're extremely close to our true parameters of `Normal(5,3)`, though with a fairly high variance due to the low sample size.
+A symmetric random-walk proposal has ``q(\theta \mid \theta') = q(\theta' \mid \theta)``, so the ratio of proposal densities cancels and the log acceptance probability is ``\min[0, \log \pi(\theta') - \log \pi(\theta)]``.
+
+The first `step` chooses the starting point.
+`sample` passes its `initial_params` keyword argument through to this method, so the sampler honours it and otherwise draws a start from the proposal distribution.
+
+```{julia}
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::AbstractMCMC.LogDensityModel,
+    sampler::MetropolisHastings;
+    initial_params=nothing,
+    kwargs...,
+)
+    θ = initial_params === nothing ? rand(rng, sampler.proposal) : initial_params
+    lp = LogDensityProblems.logdensity(model.logdensity, θ)
+    return θ, MHState(θ, lp)
+end
+```
+
+Every later `step` proposes a move from the current state and accepts or rejects it.
+On rejection it returns the current position again, together with the unchanged state.
+
+```{julia}
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::AbstractMCMC.LogDensityModel,
+    sampler::MetropolisHastings,
+    state::MHState;
+    kwargs...,
+)
+    θ_proposed = state.θ + rand(rng, sampler.proposal)
+    lp_proposed = LogDensityProblems.logdensity(model.logdensity, θ_proposed)
+    if log(rand(rng)) < lp_proposed - state.lp
+        return θ_proposed, MHState(θ_proposed, lp_proposed)
+    else
+        return state.θ, state
+    end
+end
+```
+
+### Sampling
+
+That is the whole sampler.
+`sample` runs the two methods, discards the first 2000 draws, and returns the remaining transitions as a vector.
+
+```{julia}
+sampler = MetropolisHastings(MvNormal(zeros(2), 0.25 * I))
+draws = AbstractMCMC.sample(
+    Xoshiro(2), model, sampler, 20_000; initial_params=[0.0, 1.0], discard_initial=2_000
+)
+θs = reduce(hcat, draws)
+mean(θs; dims=2)
+```
+
+The posterior means sit close to the sample mean and standard deviation of the data, as they should under a flat prior.
+
+```{julia}
+mean(data), std(data)
+```
+
+Several chains, in parallel, need no extra code.
+With `MCMCThreads()`, `initial_params` takes one starting point per chain.
+
+```{julia}
+chains = AbstractMCMC.sample(
+    Xoshiro(3),
+    model,
+    sampler,
+    AbstractMCMC.MCMCThreads(),
+    5_000,
+    3;
+    initial_params=fill([0.0, 1.0], 3),
+    discard_initial=1_000,
+)
+[mean(reduce(hcat, chain); dims=2) for chain in chains]
+```
+
+### Chain formats
+
+By default `sample` returns the vector of transitions, which is what `chain_type=Any` means.
+To return a richer object, implement `AbstractMCMC.bundle_samples(samples, model, sampler, state, chain_type; kwargs...)` for the `chain_type` you want to support, and users select it with the `chain_type` keyword argument of `sample`.
+When the sampler is used on a Turing model through `externalsampler`, Turing builds its own chain from `AbstractMCMC.getparams(state)` and `AbstractMCMC.getstats(state)`, so those two methods are what to implement next.
+The [External Samplers]({{< meta usage-external-samplers >}}) page describes that path.
 
 ## Conclusion
 
-We've seen how to implement the sampling interface for general projects. Turing's interface methods are ever-evolving, so please open an issue at [AbstractMCMC](https://github.com/TuringLang/AbstractMCMC.jl) with feature requests or problems.
+Two `step` methods and a sampler type are enough to plug a new algorithm into `sample`, and from there into Turing.
+The interface keeps evolving, so please open an issue at [AbstractMCMC](https://github.com/TuringLang/AbstractMCMC.jl) with feature requests or problems.

--- a/faq/index.qmd
+++ b/faq/index.qmd
@@ -60,28 +60,26 @@ See the [Core Functionality guide]({{<meta core-functionality>}}#sampling-multip
 ### 2. Threading Within Models
 
 Using threads inside your model (e.g., `Threads.@threads`) requires more care.
-In particular, only threaded **observe** statements are safe to use; threaded **assume** statements can lead to crashes or incorrect results.
+Ordinary Julia code can be parallelised freely, but any tilde-statement or `@addlogprob!` inside a threaded block needs the model to be marked with `setthreadsafe`.
 Please see the [Threadsafe Evaluation page]({{< meta usage-threadsafe-evaluation >}}) for complete details.
 
 ```julia
 @model function f(y)
     x = Vector{Float64}(undef, length(y))
     Threads.@threads for i in eachindex(y)
-        # This would be unsafe!
-        # x[i] ~ Normal()
-        # This is safe:
-        y[i] ~ Normal()
+        x[i] ~ Normal()
+        y[i] ~ Normal(x[i])
     end
 end
-# If you have parallel tilde-statements or `@addlogprob!` in a model, 
-# you must mark the model as threadsafe:
+# Parallel tilde-statements or `@addlogprob!` require the threadsafe flag:
 model = setthreadsafe(f(y), true)
 ```
 
 **Important limitations:**
 
-- **Observe statements**: Generally safe to use in threaded loops
-- **Assume statements** (sampling statements): Often crash unpredictably or produce incorrect results
+- **Without `setthreadsafe`**: threaded tilde-statements give wrong results or errors
+- **Reproducibility**: threaded **assume** statements are supported but are not guaranteed to give the same draws for the same seed. Threaded **observe** statements are fully reproducible
+- **Performance**: threadsafe evaluation costs extra, so only enable it for models that need it
 - **AD backend compatibility**: Many AD backends don't support threading. See the [Threadsafe Evaluation]({{< meta usage-threadsafe-evaluation >}}) page for which backends work reliably
 
 ## How do I check the type stability of my Turing model?

--- a/faq/index.qmd
+++ b/faq/index.qmd
@@ -77,7 +77,7 @@ model = setthreadsafe(f(y), true)
 
 **Important limitations:**
 
-- **Without `setthreadsafe`**: threaded tilde-statements give wrong results or errors
+- **Without `setthreadsafe`**: threaded tilde-statements may give wrong results or errors
 - **Reproducibility**: threaded **assume** statements are supported but are not guaranteed to give the same draws for the same seed. Threaded **observe** statements are fully reproducible
 - **Performance**: threadsafe evaluation costs extra, so only enable it for models that need it
 - **AD backend compatibility**: Many AD backends don't support threading. See the [Threadsafe Evaluation]({{< meta usage-threadsafe-evaluation >}}) page for which backends work reliably

--- a/tutorials/bayesian-linear-regression/index.qmd
+++ b/tutorials/bayesian-linear-regression/index.qmd
@@ -138,7 +138,7 @@ Lastly, each observation $y_i$ is distributed according to the calculated `mu` t
 end
 ```
 
-With our model specified, we can call the sampler. We will use the No U-Turn Sampler ([NUTS](https://turinglang.org/stable/docs/library/#Turing.Inference.NUTS)) here.
+With our model specified, we can call the sampler. We will use the No U-Turn Sampler ([NUTS](https://turinglang.org/Turing.jl/stable/api/Inference/#Turing.Inference.NUTS)) here.
 
 ```{julia}
 model = linear_regression(train, train_target)

--- a/tutorials/bayesian-logistic-regression/index.qmd
+++ b/tutorials/bayesian-logistic-regression/index.qmd
@@ -134,7 +134,7 @@ end;
 ## Sampling
 
 Now we can run our sampler.
-Here we'll use [`NUTS`](https://turinglang.org/stable/docs/library/#Turing.Inference.NUTS) to sample from our posterior.
+Here we'll use [`NUTS`](https://turinglang.org/Turing.jl/stable/api/Inference/#Turing.Inference.NUTS) to sample from our posterior.
 
 ```{julia}
 #| output: false

--- a/tutorials/coin-flipping/index.qmd
+++ b/tutorials/coin-flipping/index.qmd
@@ -166,7 +166,7 @@ rand(coinflip(; N))
 ```
 
 The model can be conditioned on observations using the `|` operator, which fixes certain variables to observed values.
-See the [documentation of the `condition` syntax](https://turinglang.github.io/DynamicPPL.jl/stable/api/#Condition-and-decondition) in `DynamicPPL.jl` for more details.
+See the [documentation of the `condition` syntax](https://turinglang.org/DynamicPPL.jl/stable/api/#Condition-and-decondition) in `DynamicPPL.jl` for more details.
 In the conditioned model below, the observations `y` are fixed to `data`.
 
 ```{julia}
@@ -189,7 +189,7 @@ We approximate the posterior distribution with 1000 samples:
 chain = sample(model, sampler, 2_000, progress=false);
 ```
 
-The `sample` function and common keyword arguments are explained more extensively in the documentation of [AbstractMCMC.jl](https://turinglang.github.io/AbstractMCMC.jl/dev/api/).
+The `sample` function and common keyword arguments are explained more extensively in the documentation of [AbstractMCMC.jl](https://turinglang.org/AbstractMCMC.jl/dev/api/).
 
 After finishing the sampling process, we can visually compare the closed-form posterior distribution with the approximation obtained with Turing.
 

--- a/tutorials/infinite-mixture-models/index.qmd
+++ b/tutorials/infinite-mixture-models/index.qmd
@@ -97,11 +97,12 @@ which resembles the model in the [Gaussian mixture model tutorial]({{<meta gauss
 
 The question now arises, is there a generalization of a Dirichlet distribution for which the dimensionality $K$ is infinite, i.e. $K = \infty$?
 
-But first, to implement an infinite Gaussian mixture model in Turing, we first need to load the `Turing.RandomMeasures` module.
-`RandomMeasures` contains a variety of tools useful in nonparametrics.
+But first, to implement an infinite Gaussian mixture model in Turing, we need the random-measure distributions that Turing ships in its `TuringDistributionsExt` package extension.
+The extension loads together with Turing, and its module is reached through `Base.get_extension`.
 
 ```{julia}
-using Turing.RandomMeasures
+const RandomMeasures = Base.get_extension(Turing, :TuringDistributionsExt)
+using .RandomMeasures: DirichletProcess, ChineseRestaurantProcess
 ```
 
 We now will utilize the fact that one can integrate out the mixing weights in a Gaussian mixture model allowing us to arrive at the Chinese restaurant process construction.

--- a/tutorials/multinomial-logistic-regression/index.qmd
+++ b/tutorials/multinomial-logistic-regression/index.qmd
@@ -118,7 +118,7 @@ end;
 ## Sampling
 
 Now we can run our sampler.
-Here we'll use [`NUTS`](https://turinglang.org/stable/docs/library/#Turing.Inference.NUTS) to sample from our posterior.
+Here we'll use [`NUTS`](https://turinglang.org/Turing.jl/stable/api/Inference/#Turing.Inference.NUTS) to sample from our posterior.
 
 ```{julia}
 #| output: false

--- a/usage/external-samplers/index.qmd
+++ b/usage/external-samplers/index.qmd
@@ -130,17 +130,29 @@ The output of both of these methods must be a tuple containing:
  - a 'transition', which is essentially the 'visible output' of the sampler: this object is later used to construct an `FlexiChains.VNChain`;
  - a 'state', representing the current state of the sampler, which is passed to the next step of the MCMC algorithm.
 
-Apart from this, your sampler state should also implement `AbstractMCMC.getparams(model, state)` to return the parameters of the model as a vector.
-Here, `transition` represents the first output of the `step` function.
+Apart from this, your sampler state should also implement `AbstractMCMC.getparams(state)`, which returns the parameters as a vector exactly as your sampler sees them, and `AbstractMCMC.getstats(state)`, which returns a `NamedTuple` of sampler statistics for the step (or `NamedTuple()` if there are none).
+Both take the state, not the transition.
 
 ```julia
-function AbstractMCMC.getparams(model::AbstractMCMC.LogDensityModel, state::MyState)
+function AbstractMCMC.getparams(state::MyState)
     # Return a vector containing the parameters of the model.
+end
+
+function AbstractMCMC.getstats(state::MyState)
+    # Return a NamedTuple of statistics, e.g. (; accepted=state.accepted).
 end
 ```
 
 These functions are the bare minimum that your external sampler must implement to work with Turing models.
 There are other methods which can be overloaded to improve the performance or other features of the sampler; please refer to the documentation linked above for more details.
+Two of them deserve a mention here.
+
+If your sampler adapts during warmup, implement `AbstractMCMC.step_warmup` with the same signatures as `step`.
+Turing routes the `num_warmup` iterations through it, and samplers that do not define it fall back to `step`.
+
+To use the sampler as a component of `Gibbs`, define the three-argument `AbstractMCMC.setparams!!(model::AbstractMCMC.LogDensityModel, state, params)`.
+Gibbs re-conditions the model between sweeps, so this method must recompute any log density the state caches rather than only writing `params` into it.
+Turing refuses an external sampler whose state only has the two-argument `setparams!!(state, params)`, because that form cannot see the re-conditioned model.
 
 In general, we recommend that the `AbstractMCMC` interface is implemented directly in your library.
 However, any DynamicPPL- or Turing-specific functionality is best implemented in a `MySamplerTuringExt` extension.

--- a/usage/mode-estimation/index.qmd
+++ b/usage/mode-estimation/index.qmd
@@ -151,6 +151,7 @@ maximum_likelihood(model; lb=lb, ub=ub)
 Turing will internally translate these bounds to unconstrained space if `link=true`; as a user you should not need to worry at all about the details of this transformation.
 
 In this case we only have one parameter, but if there are multiple parameters and you only want to constrain some of them, you can provide bounds for the parameters you want to constrain and omit the others.
+A bound must cover a whole variable: bounding only `x[1]` of a vector `x` is an error, and a bound on a name the model never reaches produces a warning rather than being ignored.
 
 Note that for some distributions (e.g. `Dirichlet`, `LKJCholesky`), the mapping from model-space bounds to linked-space bounds is not well-defined.
 In these cases, Turing will raise an error.

--- a/usage/mode-estimation/index.qmd
+++ b/usage/mode-estimation/index.qmd
@@ -151,7 +151,9 @@ maximum_likelihood(model; lb=lb, ub=ub)
 Turing will internally translate these bounds to unconstrained space if `link=true`; as a user you should not need to worry at all about the details of this transformation.
 
 In this case we only have one parameter, but if there are multiple parameters and you only want to constrain some of them, you can provide bounds for the parameters you want to constrain and omit the others.
-A bound must cover a whole variable: bounding only `x[1]` of a vector `x` is an error, and a bound on a name the model never reaches produces a warning rather than being ignored.
+A bound must cover the complete value of a tilde site.
+Bounding only `x[1]` is valid when the model declares elements separately with `x[i] ~ Normal()`, but errors for `x ~ MvNormal(...)`.
+A bound on a name the model never reaches produces a warning.
 
 Note that for some distributions (e.g. `Dirichlet`, `LKJCholesky`), the mapping from model-space bounds to linked-space bounds is not well-defined.
 In these cases, Turing will raise an error.

--- a/usage/sampler-visualisation/index.qmd
+++ b/usage/sampler-visualisation/index.qmd
@@ -150,6 +150,7 @@ plot_sampler(c4)
 ```
 
 As you can see, the MH sampler doesn't move parameter estimates very often.
+`MH()` proposes from the prior. Passing a covariance matrix, as in `MH(0.1 * I(2))`, instead performs a Gaussian random walk over the complete linked parameter vector.
 
 ### NUTS
 

--- a/usage/sampler-visualisation/index.qmd
+++ b/usage/sampler-visualisation/index.qmd
@@ -185,7 +185,7 @@ plot_sampler(c7)
 
 The Particle Gibbs (PG) sampler is an implementation of an algorithm from the paper ["Particle Markov chain Monte Carlo methods"](https://www.stats.ox.ac.uk/~doucet/andrieu_doucet_holenstein_PMCMC.pdf) by Andrieu, Doucet, and Holenstein (2010).
 
-The `PG` sampler takes a single parameter, which is the number of particles.
+The first argument of `PG` is the number of particles, and an optional second argument selects the resampling scheme.
 
 ```{julia}
 c8 = sample(Xoshiro(468), model, PG(20), 1000)

--- a/usage/sampler-visualisation/index.qmd
+++ b/usage/sampler-visualisation/index.qmd
@@ -150,7 +150,7 @@ plot_sampler(c4)
 ```
 
 As you can see, the MH sampler doesn't move parameter estimates very often.
-`MH()` proposes from the prior. Passing a covariance matrix, as in `MH(0.1 * I(2))`, instead performs a Gaussian random walk over the complete linked parameter vector.
+`MH()` proposes from the prior. Passing a covariance matrix, as in `MH(0.1 * I(2))`, instead performs a Gaussian random walk over the unconstrained parameter vector.
 
 ### NUTS
 

--- a/usage/sampling-options/index.qmd
+++ b/usage/sampling-options/index.qmd
@@ -274,7 +274,7 @@ If you wish to disable this you can pass `check_model=false` to `sample()`.
 ## Callbacks
 
 The `callback` keyword argument can be used to specify a function that is called at the end of each sampler iteration.
-This function should have the signature `callback(rng, model, sampler, sample, iteration::Int; kwargs...)`.
+This function should have the signature `callback(rng, model, sampler, sample, state, iteration::Int; kwargs...)`, where `state` is the sampler state after that iteration.
 
 If you are performing multi-chain sampling, `kwargs` will additionally contain `chain_number::Int`, which ranges from 1 to the number of chains.
 

--- a/usage/sampling-options/index.qmd
+++ b/usage/sampling-options/index.qmd
@@ -273,8 +273,9 @@ If you wish to disable this you can pass `check_model=false` to `sample()`.
 
 ## Callbacks
 
-The `callback` keyword argument can be used to specify a function that is called at the end of each sampler iteration.
-This function should have the signature `callback(rng, model, sampler, sample, state, iteration::Int; kwargs...)`, where `state` is the sampler state after that iteration.
+The `callback` keyword argument can be used to specify a function that is called each time a sample is kept.
+This function should have the signature `callback(rng, model, sampler, sample, state, iteration::Int; kwargs...)`, where `state` is the sampler state that produced the sample and `iteration` counts kept samples from 1 to the number requested.
+Steps that are discarded through `num_warmup`, `discard_initial` or `thinning` do not trigger the callback.
 
 If you are performing multi-chain sampling, `kwargs` will additionally contain `chain_number::Int`, which ranges from 1 to the number of chains.
 

--- a/usage/sampling-options/index.qmd
+++ b/usage/sampling-options/index.qmd
@@ -254,7 +254,8 @@ Here are some examples of how these two keyword arguments interact:
 Each sampler has its own default value for `num_warmup`, but `discard_initial` always defaults to `num_warmup`.
 
 Warmup steps and 'regular' non-warmup steps differ in that warmup steps call `AbstractMCMC.step_warmup`, whereas regular steps call `AbstractMCMC.step`.
-For all the samplers defined in Turing, these two functions are identical; however, they may in general differ for other samplers.
+For the samplers defined in Turing, these two functions are identical.
+`externalsampler` forwards warmup steps to the wrapped sampler's `step_warmup`, so an external sampler that adapts during warmup, such as `AdvancedMH.RobustAdaptiveMetropolis`, adapts as intended, and `Gibbs` passes warmup steps on to its component samplers.
 Please consult the documentation of the respective sampler for details.
 
 A thinning factor can be specified using the `thinning` keyword argument.

--- a/usage/sampling-options/index.qmd
+++ b/usage/sampling-options/index.qmd
@@ -275,7 +275,9 @@ If you wish to disable this you can pass `check_model=false` to `sample()`.
 
 The `callback` keyword argument can be used to specify a function that is called each time a sample is kept.
 This function should have the signature `callback(rng, model, sampler, sample, state, iteration::Int; kwargs...)`, where `state` is the sampler state that produced the sample and `iteration` counts kept samples from 1 to the number requested.
-Steps that are discarded through `num_warmup`, `discard_initial` or `thinning` do not trigger the callback.
+Steps that are discarded through `discard_initial` or `thinning` do not trigger the callback.
+Warmup steps are only skipped when they are discarded, so with `discard_initial` smaller than `num_warmup` the kept warmup samples trigger it too.
+`SMC` runs a single sweep instead of an MCMC loop and ignores `callback` with a warning.
 
 If you are performing multi-chain sampling, `kwargs` will additionally contain `chain_number::Int`, which ranges from 1 to the number of chains.
 

--- a/usage/sampling-options/index.qmd
+++ b/usage/sampling-options/index.qmd
@@ -254,8 +254,8 @@ Here are some examples of how these two keyword arguments interact:
 Each sampler has its own default value for `num_warmup`, but `discard_initial` always defaults to `num_warmup`.
 
 Warmup steps and 'regular' non-warmup steps differ in that warmup steps call `AbstractMCMC.step_warmup`, whereas regular steps call `AbstractMCMC.step`.
-For the samplers defined in Turing, these two functions are identical.
-`externalsampler` forwards warmup steps to the wrapped sampler's `step_warmup`, so an external sampler that adapts during warmup, such as `AdvancedMH.RobustAdaptiveMetropolis`, adapts as intended, and `Gibbs` passes warmup steps on to its component samplers.
+Turing's own kernels, such as `HMC`, `NUTS`, `MH` and `PG`, do not distinguish the two.
+The wrappers do: `externalsampler` forwards warmup steps to the wrapped sampler's `step_warmup`, so an external sampler that adapts during warmup, such as `AdvancedMH.RobustAdaptiveMetropolis`, adapts as intended, and `Gibbs` and `RepeatSampler` pass warmup steps on to the samplers they wrap.
 Please consult the documentation of the respective sampler for details.
 
 A thinning factor can be specified using the `thinning` keyword argument.

--- a/usage/submodels/index.qmd
+++ b/usage/submodels/index.qmd
@@ -268,6 +268,39 @@ ps = to_submodel(priors(x))
 (; c0, c1, mu) = ps
 ```
 
+## Stan programs as distributions
+
+A Stan program can also appear on the right-hand side of a tilde-statement, through DynamicPPL's `to_distribution`.
+This needs the BridgeStan package and a working Stan toolchain, so the example below is not executed here.
+
+```julia
+using BridgeStan, DynamicPPL, Turing
+
+const STAN = raw"""
+parameters {
+  real location;
+  real<lower=0> scale;
+}
+model {
+  location ~ normal(0, 1);
+  scale ~ lognormal(0, 1);
+}
+"""
+
+@model function demo(stan, y)
+    params ~ to_distribution(stan)
+    return y ~ Normal(params[1], params[2])
+end
+
+chain = sample(demo(STAN, 0.4), NUTS(), 1000)
+```
+
+The left-hand side receives Stan's constrained parameters as a flat vector in declaration order, so `params[1]` is `location` and `params[2]` is `scale`, and the Stan model block contributes its log density to the joint.
+The first call for a given program compiles it with BridgeStan and identical calls reuse the cached distribution.
+Both ForwardDiff and Mooncake can differentiate through the embedded program.
+Unlike `to_submodel`, which returns the submodel's return value and records its latent variables under a prefix, `to_distribution` treats the whole Stan parameter vector as one variable.
+The [DynamicPPL documentation](https://turinglang.org/DynamicPPL.jl/stable/to_distribution_and_to_submodel/) describes the `data`, `seed`, `stanc_args` and `make_args` keywords.
+
 ## Submodels versus distributions
 
 Finally, we end with a discussion of why some of the behaviour for submodels above has come about.

--- a/usage/threadsafe-evaluation/index.qmd
+++ b/usage/threadsafe-evaluation/index.qmd
@@ -78,7 +78,8 @@ x, __abstractvarinfo__ = DynamicPPL.tilde_assume!!(..., __abstractvarinfo__)
 and writing into `__abstractvarinfo__` is, _in general_, not threadsafe.
 Thus, parallelising tilde-statements can lead to data races [as described in the Julia manual](https://docs.julialang.org/en/v1/manual/multi-threading/#Using-@threads-without-data-races).
 
-Turing's threadsafe flag works by creating one `AbstractVarInfo` per thread, and then combining the results at the end of model evaluation.
+Turing's threadsafe flag works by giving each task its own accumulator state, and then combining the results at the end of model evaluation.
+The state follows the task rather than the thread, so a task that yields or migrates between threads keeps its own updates.
 :::
 
 Once the model has been marked as threadsafe, Turing guarantees to provide the correct result in functions such as:
@@ -265,7 +266,7 @@ Metadata is where information about the random variables' values are stored.
 It is a Dict-like structure, and pushing to it from multiple threads is therefore not threadsafe (Julia's `Dict` has similar limitations).
 
 On the other hand, accumulators are used to store outputs of the model, such as log-probabilities
-The way DynamicPPL's threadsafe evaluation works is to create one set of accumulators per thread, and then combine the results at the end of model evaluation.
+The way DynamicPPL's threadsafe evaluation works is to give each task its own set of accumulators, and then combine the results at the end of model evaluation.
 
 In this way, any function call that _solely_ involving accumulators can be made threadsafe.
 For example, this is why observations are supported: there is no need to modify metadata, and only the log-likelihood accumulator needs to be updated.

--- a/usage/varnamedtuple/index.qmd
+++ b/usage/varnamedtuple/index.qmd
@@ -71,6 +71,14 @@ res.params[@varname(x)]
 
 even though `x` itself was never on the left-hand side of a tilde-statement (only `x[1]` and `x[2]` were).
 This is not possible with a `Dict{VarName}`.
+
+For a whole variable, a `Symbol` is accepted as shorthand for the identity `VarName`, so `res.params[:x]` is the same as `res.params[@varname(x)]`.
+Indexed or nested variables still need a `VarName`.
+
+```{julia}
+res.params[:x]
+```
+
 You can even do things like:
 
 ```{julia}

--- a/usage/vectorisation/index.qmd
+++ b/usage/vectorisation/index.qmd
@@ -162,6 +162,9 @@ N = LogDensityProblems.dimension(ldf_linked)
 LogDensityProblems.logdensity(ldf_linked, randn(N))
 ```
 
+The vector passed to `logdensity` must have exactly `dimension(ldf)` elements.
+A vector of the wrong length throws an `ArgumentError` naming both lengths, rather than failing somewhere inside model evaluation or silently using only the first few elements.
+
 ## Automatic differentiation
 
 The `LogDensityFunction` that we created above does not yet know how to compute gradients of the parameters on its own.
@@ -212,6 +215,40 @@ LogDensityFunction(model, logdensity_function, ranges_and_transforms, sample_vec
 ```
 
 Please see the DynamicPPL API documentation for more information on these arguments.
+
+## Minibatch log densities
+
+Stochastic inference algorithms, such as those in AdvancedVI and stochastic-gradient variants of HMC, evaluate the log density on a minibatch of the data and scale the likelihood up to the full dataset.
+`subsample` builds a `LogDensityFunction` for one such minibatch.
+
+The observation has to be written with `independent_distribution`, which declares that the data are conditionally independent draws, and the full dataset has to be supplied by conditioning rather than as a model argument.
+
+```{julia}
+@model function location_model()
+    μ ~ Normal()
+    x ~ independent_distribution(Normal(μ))
+end
+data = [-1.0, 0.5, 1.0]
+full_model = location_model() | (x = data,)
+```
+
+`subsample(model, indices, dataset_size)` fixes the minibatch to the given indices, and `subsample(model, batch_size, dataset_size)` draws `batch_size` indices uniformly without replacement.
+The likelihood of the selected observations is multiplied by `dataset_size / batch_size`, while the prior enters once.
+
+```{julia}
+ldf_batch = subsample(full_model, [1, 3], length(data))
+LogDensityProblems.logdensity(ldf_batch, [0.2])
+```
+
+which is the prior plus the scaled likelihood of observations 1 and 3:
+
+```{julia}
+logpdf(Normal(), 0.2) + (3 / 2) * (logpdf(Normal(0.2), data[1]) + logpdf(Normal(0.2), data[3]))
+```
+
+The minibatch stays fixed for the life of the `LogDensityFunction`, so an algorithm that wants a fresh batch at every step constructs a new one each time.
+Pass `transform_strategy=LinkAll()` when the algorithm needs unconstrained parameters.
+The [DynamicPPL documentation on subsampling](https://turinglang.org/DynamicPPL.jl/stable/ldf/subsampling/) covers custom resamplers and the unbiasedness condition they must satisfy.
 
 ## Conversions between `VarNamedTuple` and vectors
 

--- a/usage/vectorisation/index.qmd
+++ b/usage/vectorisation/index.qmd
@@ -222,6 +222,9 @@ Stochastic inference algorithms, such as those in AdvancedVI and stochastic-grad
 `subsample` builds a `LogDensityFunction` for one such minibatch.
 
 The observation has to be written with `independent_distribution`, which declares that the data are conditionally independent draws, and the full dataset has to be supplied by conditioning rather than as a model argument.
+The model must have exactly one conditioned observation, and it must be the last probability-bearing statement.
+For example, placing an independent prior after that observation causes an error.
+Additional likelihood contributions through `@addlogprob!` are not supported.
 
 ```{julia}
 @model function location_model()


### PR DESCRIPTION
The interface guide described the AbstractMCMC v1 interface and its code cells were `eval: false`, so CI never noticed. It is rewritten on the current interface with every cell executed.

The `to_distribution` example is not executed because it needs BridgeStan and a Stan toolchain.